### PR TITLE
fix(pb-i18n): fix concurrency issue

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -7,7 +7,8 @@
         "demo/pb-document.html": "Demo"
     },
     "pb-browse-docs": {
-        "demo/pb-browse-docs.html": "Demo"
+        "demo/pb-browse-docs.html": "Demo",
+        "demo/pb-browse-docs2.html": "Passing parameters from a custom form"
     },
     "pb-code-editor": {
         "demo/pb-code-editor.html": "Demo"

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -84,7 +84,8 @@
         "demo/pb-repeat.html": "Demo"
     },
     "pb-search": {
-        "demo/pb-search.html": "Demo"
+        "demo/pb-search.html": "Demo",
+        "demo/pb-search2.html": "With nested pb-select"
     },
     "pb-select-feature": {
         "demo/pb-select-feature.html": "Server-side",

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -129,6 +129,7 @@
     "pb-select": {
         "demo/pb-select.html": "Demo",
         "demo/pb-select2.html": "Read options from remote datasource",
-        "demo/pb-select3.html": "Combined filter options"
+        "demo/pb-select3.html": "Combined filter options",
+        "demo/pb-select-i18n.html": "Use with i18n"
     }
 }

--- a/demo/pb-autocomplete.html
+++ b/demo/pb-autocomplete.html
@@ -21,18 +21,30 @@
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <h2>Suggestion list passed in a property</h2>
-                    <pb-autocomplete placeholder="type" suggestions='["alpha", "beta", "gamma"]'></pb-autocomplete>
-                    <h2>Suggestion list supplied by remote XQuery</h2>
-                    <pb-autocomplete placeholder="query" source="modules/autocomplete.xql"></pb-autocomplete>
-                    <h2>Combine with other form fields whose value is passed on</h2>
-                    <pb-autocomplete placeholder="query" source="modules/autocomplete.xql">
-                        <select name="field">
-                            <option value="title">Title</option>
-                            <option value="author">Author</option>
-                        </select>
-                    </pb-autocomplete>
+                    <form action="" id="form">
+                        <h2>Suggestion list passed in a property</h2>
+                        <pb-autocomplete name="autocomplete1" placeholder="type" suggestions='["alpha", "beta", "gamma"]'></pb-autocomplete>
+                        <h2>Suggestion list supplied by remote XQuery</h2>
+                        <pb-autocomplete name="autocomplete2" placeholder="query" source="modules/autocomplete.xql"></pb-autocomplete>
+                        <h2>Combine with other form fields whose value is passed on</h2>
+                        <pb-autocomplete name="autocomplete3" placeholder="query" source="modules/autocomplete.xql">
+                            <select name="field">
+                                <option value="title">Title</option>
+                                <option value="author">Author</option>
+                            </select>
+                        </pb-autocomplete>
+                        <button type="submit"><paper-button>Submit</paper-button></button>
+                    </form>
+                    <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
+                <script>
+                    const form = document.getElementById('form');
+                    form.addEventListener('submit', (ev) => {
+                        ev.preventDefault();
+                        const data = new URLSearchParams(new FormData(form)).toString();
+                        document.getElementById('output').innerHTML = data;
+                    });
+                </script>
             </template>
         </pb-demo-snippet>
     </body>

--- a/demo/pb-autocomplete2.html
+++ b/demo/pb-autocomplete2.html
@@ -30,7 +30,7 @@
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <iron-form id="form" >
+                    <iron-form id="form">
                         <form action="">
                             <p>pb-autocomplete used with a pb-repeat:</p>
                             <pb-repeat>

--- a/demo/pb-autocomplete2.html
+++ b/demo/pb-autocomplete2.html
@@ -20,6 +20,8 @@
         <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
         <script type="module" src="../src/pb-autocomplete.js"></script>
         <script type="module" src="../src/pb-repeat.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
+        
         <!--/scripts-->
     </head>
     <body>
@@ -28,28 +30,30 @@
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <form id="form" action="">
-                        <p>pb-autocomplete used with a pb-repeat:</p>
-                        <pb-repeat>
-                            <template>
-                                <pb-autocomplete placeholder="Title" name="title" source="modules/autocomplete.xql"></pb-autocomplete>
-                            </template>
-                        </pb-repeat>
-                        <p>If suggestions are an array of objects with properties "text" and "value", the "value" will be used
-                            in the form submit instead of the label displayed:
-                        </p>
-                        <pb-autocomplete name="lang" placeholder="Language" value="pl" icon="icons:flag"
-                            suggestions='[{"text": "English", "value": "en"}, {"text": "Polish", "value": "pl"}, {"text": "German", "value": "de"}]'>
-                        </pb-autocomplete>
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                    <iron-form id="form" >
+                        <form action="">
+                            <p>pb-autocomplete used with a pb-repeat:</p>
+                            <pb-repeat>
+                                <template>
+                                    <pb-autocomplete placeholder="Title" name="title" source="modules/autocomplete.xql"></pb-autocomplete>
+                                </template>
+                            </pb-repeat>
+                            <p>If suggestions are an array of objects with properties "text" and "value", the "value" will be used
+                                in the form submit instead of the label displayed:
+                            </p>
+                            <pb-autocomplete name="lang" placeholder="Language" value="pl" icon="icons:flag"
+                                suggestions='[{"text": "English", "value": "en"}, {"text": "Polish", "value": "pl"}, {"text": "German", "value": "de"}]'>
+                            </pb-autocomplete>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('submit', (ev) => {
+                    form.addEventListener('iron-form-submit', (ev) => {
                         ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        const data = JSON.stringify(form.serializeForm());
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/demo/pb-browse-docs2.html
+++ b/demo/pb-browse-docs2.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-browse-docs Demo</title>
+    <link rel="stylesheet" href="demo.css">
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
+    <script type="module" src="../node_modules/@polymer/paper-item/paper-item.js"></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-fab/paper-fab.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-checkbox/paper-checkbox.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-lang.js"></script>
+    <script type="module" src="../src/pb-load.js"></script>
+    <script type="module" src="../src/pb-browse-docs.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <script type="module" src="../src/pb-upload.js"></script>
+    <script type="module" src="../src/pb-login.js"></script>
+    <script type="module" src="../src/pb-restricted.js"></script>
+    <script type="module" src="../src/pb-progress.js"></script>
+    <script type="module" src="../src/pb-custom-form.js"></script>
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style>
+                body {
+                    --paper-fab-background: #35424b;
+                }
+                .transcription {
+                    margin-left: auto;
+                    margin-right: auto;
+                }
+                pb-link a {
+                    text-decoration: none;
+                    color: #222222;
+                }
+                h5 {
+                    font-size: 16px;
+                    margin: 0;
+                }
+                .parent-link {
+                    display: block;
+                    margin-bottom: 10px;
+                    margin-top: 10px;
+                    padding: 6px 0;
+                    border-bottom: thin solid var(--paper-grey-300);
+                }
+                .documents {
+                    list-style: none;
+                    padding: 0;
+                }
+                .documents li {
+                    display: flex;
+                    flex-direction: row;
+                    margin-bottom: 10px;
+                    padding: 6px 0;
+                    border-bottom: thin solid var(--paper-grey-300);
+                }
+                .documents app-toolbar {
+                    font-size: 14px;
+                }
+
+                .documents img {
+                margin-right: 40px;
+                }
+
+                @media (max-width: 1023px) {
+                    .documents img {
+                        display: none;
+                    }
+                }
+                
+                .toolbar {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 10px;
+                    border-bottom: 1px solid #a0a0a0;
+                }
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
+                <div class="toolbar">
+                    <pb-login id="login" group="tei"></pb-login>
+                </div>
+                <section>
+                    <pb-custom-form id="testForm" url="modules/testForm.xql" event="pb-results-received" subscribe="docs" emit="docs"/>
+                </section>
+                <main>
+                    <pb-browse-docs id="document-list" url="collection/test" fix-links
+                        sort-options='[{"label": "browse.title", "value": "title"},{"label": "browse.author", "value": "author"},{"label": "browse.modificationDate", "value": "default"}]'
+                        sort-by="title"
+                        filter-options='[{"label": "browse.title", "value": "title"},{"label": "browse.author", "value": "author"},{"label": "browse.file", "value": "file"}]'
+                        filter-by="title" auto="auto" history="history" login="login" emit="docs" subscribe="docs">
+                        <pb-paginate slot="toolbar" id="paginate" per-page="10" range="5"
+                            emit="docs" subscribe="docs"></pb-paginate>
+                    </pb-browse-docs>
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>

--- a/demo/pb-search2.html
+++ b/demo/pb-search2.html
@@ -59,6 +59,7 @@
                             <paper-item value="tei-text">In text</paper-item>
                             <paper-item value="tei-head">In headings</paper-item>
                         </pb-select>
+                    </pb-search>
                     <pb-paginate per-page="10" range="5"></pb-paginate>
                     <pb-load url="templates/search-results.html"></pb-load>
                 </main>

--- a/demo/pb-search2.html
+++ b/demo/pb-search2.html
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-search Demo</title>
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-fab/paper-fab.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-load.js"></script>
+    <script type="module" src="../src/pb-search.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <script type="module" src="../src/pb-progress.js"></script>
+    <script type="module" src="../src/pb-i18n.js"></script>
+    <script type="module" src="../src/pb-select.js"></script>
+
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style>
+            pb-search {
+                display: block;
+                --pb-search-label-color: var(--paper-grey-500, #e0e0e0);
+                --pb-search-input-color: var(--paper-grey-900, #202020);
+                --pb-search-focus-color: var(--paper-orange-500);
+            }
+            pb-progress {
+                margin-bottom: 20px;
+            }
+            pb-paginate {
+                margin-top: 40px;
+                margin-bottom: 10px;
+            }
+            pb-load {
+                height: 60vh;
+                overflow: auto;
+            }
+            #results header {
+                display: flex;
+                background-color: #F0F0F0;
+            }
+
+            #results header .count {
+                margin-right: 10px;
+            }
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
+                <pb-progress></pb-progress>
+                <main>
+                    <pb-search id="search-form">
+                        <pb-select label="search in" name="tei-target" value="tei-text">
+                            <paper-item value="tei-text">In text</paper-item>
+                            <paper-item value="tei-head">In headings</paper-item>
+                        </pb-select>
+                    <pb-paginate per-page="10" range="5"></pb-paginate>
+                    <pb-load url="templates/search-results.html"></pb-load>
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>

--- a/demo/pb-select-i18n.html
+++ b/demo/pb-select-i18n.html
@@ -11,8 +11,8 @@
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
         <script type="module" src="../node_modules/@polymer/paper-item/paper-item.js"></script>
-        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
+        <script type="module" src="../src/pb-form.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>        
         <script type="module" src="../src/pb-i18n.js"></script>        
@@ -20,7 +20,7 @@
         <!--/scripts-->
     </head>
     <body>
-        <h1>Use pb-select with i18n</h1>
+        <h1>Use pb-select with i18n and iron-form</h1>
         
         <p>This demo checks if option and selection labels are properly translated.</p>
 
@@ -45,6 +45,7 @@
                             <button type="submit"><paper-button>Submit</paper-button></button>
                         </form>
                     </iron-form>
+
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
             

--- a/demo/pb-select-i18n.html
+++ b/demo/pb-select-i18n.html
@@ -11,6 +11,7 @@
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
         <script type="module" src="../node_modules/@polymer/paper-item/paper-item.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>        
@@ -33,24 +34,26 @@
                         <paper-item value="sl">Slovenščina</paper-item>
                     </pb-lang>
         
-                    <form action="" id="form">
-                        <pb-select name="format" value="latex">
-                            <paper-item value="latex"><pb-i18n key="menu.download.pdf-latex">untranslated</pb-i18n></paper-item>
-                            <paper-item value="fo"><pb-i18n key="menu.download.pdf-fo">untranslated</pb-i18n></paper-item>
-                            <paper-item value="epub"><pb-i18n key="menu.download.epub-download">untranslated</pb-i18n></paper-item>
-                        </pb-select>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-select name="format" value="latex" multi>
+                                <paper-item value="latex"><pb-i18n key="menu.download.pdf-latex">untranslated</pb-i18n></paper-item>
+                                <paper-item value="fo"><pb-i18n key="menu.download.pdf-fo">untranslated</pb-i18n></paper-item>
+                                <paper-item value="epub"><pb-i18n key="menu.download.epub-download">untranslated</pb-i18n></paper-item>
+                            </pb-select>
 
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
             
 
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('submit', (ev) => {
+                    form.addEventListener('iron-form-submit', (ev) => {
                         ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        const data = JSON.stringify(form.serializeForm());
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/demo/pb-select-i18n.html
+++ b/demo/pb-select-i18n.html
@@ -1,0 +1,61 @@
+<html>
+    <head>
+        <title>Using pb-select</title>
+        <link rel="stylesheet" href="demo.css">
+        <style>
+            pb-autocomplete {
+                margin-bottom: 20px;
+            }
+        </style>
+        <!--scripts-->
+        <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
+        <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
+        <script type="module" src="../node_modules/@polymer/paper-item/paper-item.js"></script>
+        <script type="module" src="../src/pb-page.js"></script>
+        <script type="module" src="../src/pb-select.js"></script>
+        <script type="module" src="../src/pb-lang.js"></script>        
+        <script type="module" src="../src/pb-i18n.js"></script>        
+        <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+        <!--/scripts-->
+    </head>
+    <body>
+        <h1>Use pb-select with i18n</h1>
+        
+        <p>This demo checks if option and selection labels are properly translated.</p>
+
+        <pb-demo-snippet>
+            <template>
+                <pb-page language="fr">
+                    <pb-lang label="language" selected="en">
+                        <paper-item value="tr">Türkçe</paper-item>
+                        <paper-item value="en">English</paper-item>
+                        <paper-item value="fr">Français</paper-item>
+                        <paper-item value="sl">Slovenščina</paper-item>
+                    </pb-lang>
+        
+                    <form action="" id="form">
+                        <pb-select name="format" value="latex">
+                            <paper-item value="latex"><pb-i18n key="menu.download.pdf-latex">untranslated</pb-i18n></paper-item>
+                            <paper-item value="fo"><pb-i18n key="menu.download.pdf-fo">untranslated</pb-i18n></paper-item>
+                            <paper-item value="epub"><pb-i18n key="menu.download.epub-download">untranslated</pb-i18n></paper-item>
+                        </pb-select>
+
+                        <button type="submit"><paper-button>Submit</paper-button></button>
+                    </form>
+                    <p>Parameters which would be sent: <code id="output"></code></p>
+                </pb-page>
+            
+
+                <script>
+                    const form = document.getElementById('form');
+                    form.addEventListener('submit', (ev) => {
+                        ev.preventDefault();
+                        const data = new URLSearchParams(new FormData(form)).toString();
+                        document.getElementById('output').innerHTML = data;
+                    });
+                </script>
+            </template>
+        </pb-demo-snippet>
+       
+    </body>
+</html>

--- a/demo/pb-select.html
+++ b/demo/pb-select.html
@@ -10,6 +10,7 @@
         <!--scripts-->
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>
@@ -22,60 +23,62 @@
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <form id="form" action="">
-                        <p>Single item selection:</p>
-                        <pb-select label="language" name="lang1" value="es">
-                            <paper-item value="bg">Български</paper-item>
-                            <paper-item value="cs">český</paper-item>
-                            <paper-item value="de">Deutsch</paper-item>
-                            <paper-item value="en">English</paper-item>
-                            <paper-item value="es">Español</paper-item>
-                            <paper-item value="el">ελληνικά</paper-item>
-                            <paper-item value="fr">Français</paper-item>
-                            <paper-item value="it">Italiano</paper-item>
-                            <paper-item value="ka">ქართული</paper-item>
-                            <paper-item value="nl">Nederlands</paper-item>
-                            <paper-item value="no">Norsk</paper-item>
-                            <paper-item value="pl">Polski</paper-item>
-                            <paper-item value="pt">Português</paper-item>
-                            <paper-item value="ro">Română</paper-item>
-                            <paper-item value="ru">русский</paper-item>
-                            <paper-item value="sl">Slovenščina</paper-item>
-                            <paper-item value="sv">Svenska</paper-item>
-                            <paper-item value="tr">Türkçe</paper-item>
-                            <paper-item value="uk">Українська</paper-item>
-                        </pb-select>
-                        <p>with option "multi":</p>
-                        <pb-select label="language" name="lang2" values='["fr", "de"]' multi>
-                            <paper-item value="bg">Български</paper-item>
-                            <paper-item value="cs">český</paper-item>
-                            <paper-item value="de">Deutsch</paper-item>
-                            <paper-item value="en">English</paper-item>
-                            <paper-item value="es">Español</paper-item>
-                            <paper-item value="el">ελληνικά</paper-item>
-                            <paper-item value="fr">Français</paper-item>
-                            <paper-item value="it">Italiano</paper-item>
-                            <paper-item value="ka">ქართული</paper-item>
-                            <paper-item value="nl">Nederlands</paper-item>
-                            <paper-item value="no">Norsk</paper-item>
-                            <paper-item value="pl">Polski</paper-item>
-                            <paper-item value="pt">Português</paper-item>
-                            <paper-item value="ro">Română</paper-item>
-                            <paper-item value="ru">русский</paper-item>
-                            <paper-item value="sl">Slovenščina</paper-item>
-                            <paper-item value="sv">Svenska</paper-item>
-                            <paper-item value="tr">Türkçe</paper-item>
-                            <paper-item value="uk">Українська</paper-item>
-                        </pb-select>
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                    <iron-form id="form">
+                        <form action="">
+                            <p>Single item selection:</p>
+                            <pb-select label="language" name="lang1" value="es">
+                                <paper-item value="bg">Български</paper-item>
+                                <paper-item value="cs">český</paper-item>
+                                <paper-item value="de">Deutsch</paper-item>
+                                <paper-item value="en">English</paper-item>
+                                <paper-item value="es">Español</paper-item>
+                                <paper-item value="el">ελληνικά</paper-item>
+                                <paper-item value="fr">Français</paper-item>
+                                <paper-item value="it">Italiano</paper-item>
+                                <paper-item value="ka">ქართული</paper-item>
+                                <paper-item value="nl">Nederlands</paper-item>
+                                <paper-item value="no">Norsk</paper-item>
+                                <paper-item value="pl">Polski</paper-item>
+                                <paper-item value="pt">Português</paper-item>
+                                <paper-item value="ro">Română</paper-item>
+                                <paper-item value="ru">русский</paper-item>
+                                <paper-item value="sl">Slovenščina</paper-item>
+                                <paper-item value="sv">Svenska</paper-item>
+                                <paper-item value="tr">Türkçe</paper-item>
+                                <paper-item value="uk">Українська</paper-item>
+                            </pb-select>
+                            <p>with option "multi":</p>
+                            <pb-select label="language" name="lang2" values='["fr", "de"]' multi>
+                                <paper-item value="bg">Български</paper-item>
+                                <paper-item value="cs">český</paper-item>
+                                <paper-item value="de">Deutsch</paper-item>
+                                <paper-item value="en">English</paper-item>
+                                <paper-item value="es">Español</paper-item>
+                                <paper-item value="el">ελληνικά</paper-item>
+                                <paper-item value="fr">Français</paper-item>
+                                <paper-item value="it">Italiano</paper-item>
+                                <paper-item value="ka">ქართული</paper-item>
+                                <paper-item value="nl">Nederlands</paper-item>
+                                <paper-item value="no">Norsk</paper-item>
+                                <paper-item value="pl">Polski</paper-item>
+                                <paper-item value="pt">Português</paper-item>
+                                <paper-item value="ro">Română</paper-item>
+                                <paper-item value="ru">русский</paper-item>
+                                <paper-item value="sl">Slovenščina</paper-item>
+                                <paper-item value="sv">Svenska</paper-item>
+                                <paper-item value="tr">Türkçe</paper-item>
+                                <paper-item value="uk">Українська</paper-item>
+                            </pb-select>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('submit', (ev) => {
+                    form.addEventListener('iron-form-submit', (ev) => {
                         ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        const data = JSON.stringify(form.serializeForm());
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/demo/pb-select.html
+++ b/demo/pb-select.html
@@ -18,67 +18,64 @@
         <!--/scripts-->
     </head>
     <body>
-        <h1>Using pb-select</h1>
-        
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <iron-form id="form">
-                        <form action="">
-                            <p>Single item selection:</p>
-                            <pb-select label="language" name="lang1" value="es">
-                                <paper-item value="bg">Български</paper-item>
-                                <paper-item value="cs">český</paper-item>
-                                <paper-item value="de">Deutsch</paper-item>
-                                <paper-item value="en">English</paper-item>
-                                <paper-item value="es">Español</paper-item>
-                                <paper-item value="el">ελληνικά</paper-item>
-                                <paper-item value="fr">Français</paper-item>
-                                <paper-item value="it">Italiano</paper-item>
-                                <paper-item value="ka">ქართული</paper-item>
-                                <paper-item value="nl">Nederlands</paper-item>
-                                <paper-item value="no">Norsk</paper-item>
-                                <paper-item value="pl">Polski</paper-item>
-                                <paper-item value="pt">Português</paper-item>
-                                <paper-item value="ro">Română</paper-item>
-                                <paper-item value="ru">русский</paper-item>
-                                <paper-item value="sl">Slovenščina</paper-item>
-                                <paper-item value="sv">Svenska</paper-item>
-                                <paper-item value="tr">Türkçe</paper-item>
-                                <paper-item value="uk">Українська</paper-item>
-                            </pb-select>
-                            <p>with option "multi":</p>
-                            <pb-select label="language" name="lang2" values='["fr", "de"]' multi>
-                                <paper-item value="bg">Български</paper-item>
-                                <paper-item value="cs">český</paper-item>
-                                <paper-item value="de">Deutsch</paper-item>
-                                <paper-item value="en">English</paper-item>
-                                <paper-item value="es">Español</paper-item>
-                                <paper-item value="el">ελληνικά</paper-item>
-                                <paper-item value="fr">Français</paper-item>
-                                <paper-item value="it">Italiano</paper-item>
-                                <paper-item value="ka">ქართული</paper-item>
-                                <paper-item value="nl">Nederlands</paper-item>
-                                <paper-item value="no">Norsk</paper-item>
-                                <paper-item value="pl">Polski</paper-item>
-                                <paper-item value="pt">Português</paper-item>
-                                <paper-item value="ro">Română</paper-item>
-                                <paper-item value="ru">русский</paper-item>
-                                <paper-item value="sl">Slovenščina</paper-item>
-                                <paper-item value="sv">Svenska</paper-item>
-                                <paper-item value="tr">Türkçe</paper-item>
-                                <paper-item value="uk">Українська</paper-item>
-                            </pb-select>
-                            <button type="submit"><paper-button>Submit</paper-button></button>
-                        </form>
-                    </iron-form>
+                    <h2>Using pb-select with a standard HTML form</h2>
+                    <form id="form" action="">
+                        <p>Single item selection:</p>
+                        <pb-select label="language" name="lang1" value="es">
+                            <paper-item value="bg">Български</paper-item>
+                            <paper-item value="cs">český</paper-item>
+                            <paper-item value="de">Deutsch</paper-item>
+                            <paper-item value="en">English</paper-item>
+                            <paper-item value="es">Español</paper-item>
+                            <paper-item value="el">ελληνικά</paper-item>
+                            <paper-item value="fr">Français</paper-item>
+                            <paper-item value="it">Italiano</paper-item>
+                            <paper-item value="ka">ქართული</paper-item>
+                            <paper-item value="nl">Nederlands</paper-item>
+                            <paper-item value="no">Norsk</paper-item>
+                            <paper-item value="pl">Polski</paper-item>
+                            <paper-item value="pt">Português</paper-item>
+                            <paper-item value="ro">Română</paper-item>
+                            <paper-item value="ru">русский</paper-item>
+                            <paper-item value="sl">Slovenščina</paper-item>
+                            <paper-item value="sv">Svenska</paper-item>
+                            <paper-item value="tr">Türkçe</paper-item>
+                            <paper-item value="uk">Українська</paper-item>
+                        </pb-select>
+                        <p>with option "multi":</p>
+                        <pb-select label="language" name="lang2" values='["fr", "de"]' multi>
+                            <paper-item value="bg">Български</paper-item>
+                            <paper-item value="cs">český</paper-item>
+                            <paper-item value="de">Deutsch</paper-item>
+                            <paper-item value="en">English</paper-item>
+                            <paper-item value="es">Español</paper-item>
+                            <paper-item value="el">ελληνικά</paper-item>
+                            <paper-item value="fr">Français</paper-item>
+                            <paper-item value="it">Italiano</paper-item>
+                            <paper-item value="ka">ქართული</paper-item>
+                            <paper-item value="nl">Nederlands</paper-item>
+                            <paper-item value="no">Norsk</paper-item>
+                            <paper-item value="pl">Polski</paper-item>
+                            <paper-item value="pt">Português</paper-item>
+                            <paper-item value="ro">Română</paper-item>
+                            <paper-item value="ru">русский</paper-item>
+                            <paper-item value="sl">Slovenščina</paper-item>
+                            <paper-item value="sv">Svenska</paper-item>
+                            <paper-item value="tr">Türkçe</paper-item>
+                            <paper-item value="uk">Українська</paper-item>
+                        </pb-select>
+                        <button type="submit"><paper-button>Submit</paper-button></button>
+                    </form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('iron-form-submit', (ev) => {
+                    form.addEventListener('submit', (ev) => {
                         ev.preventDefault();
-                        const data = JSON.stringify(form.serializeForm());
+                        const data = new URLSearchParams(new FormData(form)).toString();
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/demo/pb-select2.html
+++ b/demo/pb-select2.html
@@ -9,6 +9,7 @@
         <!--scripts-->
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>
@@ -22,18 +23,20 @@
             <template>
                 <p>Reads the items to be shown from a JSON file:</p>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint=".">
-                    <form id="form" action="">
-                        <pb-select label="language" name="lang" value="pl" source="./select.json">
-                        </pb-select>
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                    <iron-form id="form">
+                        <form id="form" action="">
+                            <pb-select label="language" name="lang" value="pl" source="./select.json">
+                            </pb-select>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('submit', (ev) => {
+                    form.addEventListener('iron-form-submit', (ev) => {
                         ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        const data = JSON.stringify(form.serializeForm());
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/demo/pb-select3.html
+++ b/demo/pb-select3.html
@@ -9,6 +9,7 @@
         <!--scripts-->
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>
@@ -22,22 +23,24 @@
             <template>
                 <p>Reads the items to be shown from a JSON file:</p>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <form id="form" action="">
-                        <pb-select label="Title" name="title" source="modules/autocomplete.xql?query=s">
-                            <pb-select label="Field" name="field" slot="subform" value="title">
-                                <paper-item value="title">Title</paper-item>
-                                <paper-item value="author">Author</paper-item>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-select label="Title" name="title" source="modules/autocomplete.xql?query=s">
+                                <pb-select label="Field" name="field" slot="subform" value="title">
+                                    <paper-item value="title">Title</paper-item>
+                                    <paper-item value="author">Author</paper-item>
+                                </pb-select>
                             </pb-select>
-                        </pb-select>
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
                     const form = document.getElementById('form');
-                    form.addEventListener('submit', (ev) => {
+                    form.addEventListener('iron-form-submit', (ev) => {
                         ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        const data = JSON.stringify(form.serializeForm());
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>

--- a/src/pb-autocomplete.js
+++ b/src/pb-autocomplete.js
@@ -74,6 +74,7 @@ export class PbAutocomplete extends pbMixin(LitElement) {
         this.placeholder = 'search.placeholder';
         this.suggestions = [];
         this.lastSelected = null;
+        this._hiddenInput = null;
     }
 
     connectedCallback() {
@@ -81,6 +82,14 @@ export class PbAutocomplete extends pbMixin(LitElement) {
     }
 
     firstUpdated() {
+        const inIronForm = this.closest('iron-form,pb-search,pb-custom-form');
+        if (!inIronForm) {
+            this._hiddenInput = document.createElement('input');
+            this._hiddenInput.type = 'hidden';
+            this._hiddenInput.name = this.name;
+            this.appendChild(this._hiddenInput);
+        }
+
         const autocomplete = this.shadowRoot.getElementById('autocomplete'); 
         autocomplete.addEventListener('autocomplete-change', this._autocomplete.bind(this));
 
@@ -99,6 +108,12 @@ export class PbAutocomplete extends pbMixin(LitElement) {
                 });
                 if (value) {
                     input.value = value.text || value;
+                    if (this._hiddenInput) {
+                        this._hiddenInput.value = value.value || value;
+                    }
+                }
+                if (this._hiddenInput) {
+                    this._hiddenInput.value = this.value;
                 }
             }
         }
@@ -195,6 +210,9 @@ export class PbAutocomplete extends pbMixin(LitElement) {
         console.log('autocomplete selected %s', ev.detail.text);
         input.value = ev.detail.text;
         this.value = input.value;
+        if (this._hiddenInput) {
+            this._hiddenInput.value = this.value;
+        }
     }
 
    

--- a/src/pb-autocomplete.js
+++ b/src/pb-autocomplete.js
@@ -84,11 +84,6 @@ export class PbAutocomplete extends pbMixin(LitElement) {
         const autocomplete = this.shadowRoot.getElementById('autocomplete'); 
         autocomplete.addEventListener('autocomplete-change', this._autocomplete.bind(this));
 
-        this._hiddenInput = document.createElement('input');
-        this._hiddenInput.type = 'hidden';
-        this._hiddenInput.name = this.name;
-        this.appendChild(this._hiddenInput);
-
         if (this.value) {
             if (this.source) {
                 PbAutocomplete.waitOnce('pb-page-ready', () => {
@@ -104,9 +99,7 @@ export class PbAutocomplete extends pbMixin(LitElement) {
                 });
                 if (value) {
                     input.value = value.text || value;
-                    this._hiddenInput.value = value.value || value;
                 }
-                this._hiddenInput.value = this.value;
             }
         }
     }
@@ -127,7 +120,7 @@ export class PbAutocomplete extends pbMixin(LitElement) {
             </custom-style>
             <slot></slot>
             <paper-input id="search" type="search" name="query" @keyup="${this._handleEnter}" label="${translate(this.placeholder)}"
-                always-float-label @change="${this._changed}">
+                always-float-label>
                 ${ this.icon ? html`<iron-icon icon="${this.icon}" @click="${this._doSearch}" slot="prefix"></iron-icon>` : null}
             </paper-input>
             <paper-autocomplete-suggestions id="autocomplete" for="search" .source="${this.suggestions}" ?remote-source="${this.source}"
@@ -198,14 +191,12 @@ export class PbAutocomplete extends pbMixin(LitElement) {
 
     _autocompleteSelected(ev) {
         this.lastSelected = ev.detail.text;
-        this._hiddenInput.value = ev.detail.value;
+        const input = this.shadowRoot.getElementById('search');
+        console.log('autocomplete selected %s', ev.detail.text);
+        input.value = ev.detail.text;
+        this.value = input.value;
     }
 
-    _changed() {
-        const search = this.shadowRoot.getElementById('search');
-        if (search.value !== this.lastSelected) {
-            this._hiddenInput.value = search.value;
-        }
-    }
+   
 }
 customElements.define('pb-autocomplete', PbAutocomplete);

--- a/src/pb-page.js
+++ b/src/pb-page.js
@@ -5,6 +5,7 @@ import XHR from 'i18next-xhr-backend';
 import Backend from 'i18next-chained-backend';
 import { pbMixin } from './pb-mixin.js';
 import { resolveURL } from './utils.js';
+import { initTranslation } from "./pb-i18n.js";
 
 /**
  * Make sure there's only one instance of pb-page active at any time.
@@ -227,8 +228,8 @@ class PbPage extends pbMixin(LitElement) {
             .use(Backend)
             .init(options)
             .then((t) => {
+                initTranslation(t);
                 // initialized and ready to go!
-                this._translate = t;
                 this._updateI18n(t);
                 this.signalReady('pb-i18n-update', { t, language: i18next.language });
                 if (this.requireLanguage) {
@@ -243,7 +244,6 @@ class PbPage extends pbMixin(LitElement) {
         this.subscribeTo('pb-i18n-language', (ev) => {
             const { language } = ev.detail;
             i18next.changeLanguage(language).then((t) => {
-                this._translate = t;
                 this._updateI18n(t);
                 this.emitTo('pb-i18n-update', { t, language: i18next.language }, []);
             }, []);

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -71,19 +71,30 @@ export class PbSelect extends pbMixin(LitElement) {
     constructor() {
         super();
         this.value = null;
-        this.values = [];
+        this.values = null;
         this._items = [];
         this._selected = [];
+        this._inIronForm = false;
     }
 
     connectedCallback() {
         super.connectedCallback();
 
         this.subscribeTo('pb-i18n-update', this._refresh.bind(this));
+        // in multi-select mode, copy any value set via 'value' to 'values'
+        if (this.multi) {
+            if (!this.values && this.value) {
+                this.values = [this.value];
+            }
+            // delete this.value so it is not picked up by iron-form
+            this.value = undefined;
+        }
     }
 
     firstUpdated() {
         super.firstUpdated();
+
+        this._inIronForm = this.closest('iron-form, pb-search,pb-custom-form');
 
         const slot = this.shadowRoot.querySelector('[name="subform"]');
         if (slot) {
@@ -170,11 +181,21 @@ export class PbSelect extends pbMixin(LitElement) {
             return html`
                 <slot name="subform"></slot>
                 <iron-label for="list" part="label">${translate(this.label)}</iron-label>
-                <paper-listbox id="list" slot="dropdown-content" class="dropdown-content" .selectedValues="${this.values}" ?multi="${this.multi}"
+                ${
+                    this.multi ? 
+                html`<paper-listbox id="list" slot="dropdown-content" class="dropdown-content" 
+                    .selectedValues="${this.values}" multi
                     attr-for-selected="value" @iron-select="${this._changed}" @iron-deselect="${this._changed}">
                     <slot></slot>
                     ${this._items.map((item) => html`<paper-item value="${item.value}">${item.label}</paper-item>`)}
-                </paper-listbox>
+                </paper-listbox>` :
+                html`<paper-listbox id="list" slot="dropdown-content" class="dropdown-content" 
+                    .selected="${this.value}"
+                    attr-for-selected="value" @iron-select="${this._changed}" @iron-deselect="${this._changed}">
+                    <slot></slot>
+                    ${this._items.map((item) => html`<paper-item value="${item.value}">${item.label}</paper-item>`)}
+                </paper-listbox>`
+                }
                 <slot name="output"></slot>
             `;
         }
@@ -197,18 +218,9 @@ export class PbSelect extends pbMixin(LitElement) {
         if (this.multi) {
             this._selected = list.selectedValues;
             this.values = this._selected;
-            
-            // set value anyway for the purpose of testing serialization
-            var svalue = '';
-            this._selected.forEach((val) => {
-                if (svalue) {svalue +=', ';}
-                svalue += val;
-            });
-            this.value = '[' + svalue + ']';
         } else {
             this._selected = [list.selected];
             this.value = list.selected;
-            this.values = [];
         }
 
         // check if selected items really changed
@@ -217,6 +229,19 @@ export class PbSelect extends pbMixin(LitElement) {
             return;
         }
 
+        if (!this._inIronForm || this.multi) {
+            this._clear('[name="output"]');
+                
+            const vals = this.multi ? this.values : [this.value];
+            vals.forEach((val) => {
+                const hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = this.name;
+                hidden.value = val;
+                hidden.slot = 'output';
+                this.appendChild(hidden);
+            });
+        }
         this.dispatchEvent(new CustomEvent('change'));
     }
 

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -2,7 +2,7 @@ import { LitElement, html, css } from 'lit-element';
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-listbox";
 import "@polymer/paper-item";
-import "@polymer/iron-label";
+import "@polymer/iron-label/iron-label.js";
 import { translate } from "./pb-i18n.js";
 import { pbMixin } from './pb-mixin.js';
 
@@ -197,7 +197,14 @@ export class PbSelect extends pbMixin(LitElement) {
         if (this.multi) {
             this._selected = list.selectedValues;
             this.values = this._selected;
-            this.value = null;
+            
+            // set value anyway for the purpose of testing serialization
+            var svalue = '';
+            this._selected.forEach((val) => {
+                if (svalue) {svalue +=', ';}
+                svalue += val;
+            });
+            this.value = '[' + svalue + ']';
         } else {
             this._selected = [list.selected];
             this.value = list.selected;
@@ -209,21 +216,8 @@ export class PbSelect extends pbMixin(LitElement) {
             this._selected.every((val, index) => val === oldSelected[index])) {
             return;
         }
-        this._writeHidden();
 
         this.dispatchEvent(new CustomEvent('change'));
-    }
-
-    _writeHidden() {
-        this._clear('slot[name="output"]');
-        this._selected.forEach((item) => {
-            const input = document.createElement('input');
-            input.slot = 'output';
-            input.type = 'hidden';
-            input.name = this.name;
-            input.value = item;
-            this.appendChild(input);
-        });
     }
 
     static get styles() {

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'lit-element';
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-listbox";
 import "@polymer/paper-item";
 import "@polymer/iron-label";
@@ -180,13 +180,13 @@ export class PbSelect extends pbMixin(LitElement) {
         }
         return html`
             <slot name="subform"></slot>
-            <paper-dropdown-menu-light label="${translate(this.label)}">
+            <paper-dropdown-menu label="${translate(this.label)}">
                 <paper-listbox id="list" slot="dropdown-content" class="dropdown-content" .selected="${this.value}"
                     attr-for-selected="value" @iron-select="${this._changed}">
                     <slot></slot>
                     ${this._items.map((item) => html`<paper-item value="${item.value}">${item.label}</paper-item>`)}
                 </paper-listbox>
-            </paper-dropdown-menu-light>
+            </paper-dropdown-menu>
             <slot name="output"></slot>
         `;
     }
@@ -237,6 +237,10 @@ export class PbSelect extends pbMixin(LitElement) {
                 font-size: 12px;
                 font-weight: 400;
                 color: var(--pb-color-lighter);
+            }
+
+            paper-dropdown-menu{
+                width:100%;
             }
         `;
     }

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -76,6 +76,12 @@ export class PbSelect extends pbMixin(LitElement) {
         this._selected = [];
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+
+        this.subscribeTo('pb-i18n-update', this._refresh.bind(this));
+    }
+
     firstUpdated() {
         super.firstUpdated();
 
@@ -92,6 +98,17 @@ export class PbSelect extends pbMixin(LitElement) {
             });
         }
         this._loadRemote();
+    }
+
+    _refresh() {
+        const listbox = this.shadowRoot.getElementById('list');
+        if (listbox) {
+            setTimeout(() => {
+                const old = listbox.selected;
+                listbox.selected = undefined;
+                listbox.selected = old;
+            });
+        }
     }
 
     _clear(selector) {
@@ -163,13 +180,13 @@ export class PbSelect extends pbMixin(LitElement) {
         }
         return html`
             <slot name="subform"></slot>
-            <paper-dropdown-menu label="${translate(this.label)}">
+            <paper-dropdown-menu-light label="${translate(this.label)}">
                 <paper-listbox id="list" slot="dropdown-content" class="dropdown-content" .selected="${this.value}"
                     attr-for-selected="value" @iron-select="${this._changed}">
                     <slot></slot>
                     ${this._items.map((item) => html`<paper-item value="${item.value}">${item.label}</paper-item>`)}
                 </paper-listbox>
-            </paper-dropdown-menu>
+            </paper-dropdown-menu-light>
             <slot name="output"></slot>
         `;
     }

--- a/src/pb-view.js
+++ b/src/pb-view.js
@@ -609,7 +609,6 @@ export class PbView extends pbMixin(LitElement) {
                 this._scrollTarget = null;
             });
         }
-        this._scroll();
 
         this.next = resp.next;
         this.previous = resp.previous;
@@ -634,6 +633,8 @@ export class PbView extends pbMixin(LitElement) {
                 position: this.nodeId
             };
             this.emitTo('pb-update', eventOptions);
+
+            this._scroll();
         });
 
         this.emitTo('pb-end-update', null);
@@ -738,6 +739,7 @@ export class PbView extends pbMixin(LitElement) {
         const { hash } = this.getUrl();
         if (hash) {
             const target = this.shadowRoot.getElementById(hash.substring(1));
+            console.log('hash target: %o', target);
             if (target) {
                 target.scrollIntoView({ block: "center", inline: "nearest" });
             }

--- a/test/pb-autocomplete.test.js
+++ b/test/pb-autocomplete.test.js
@@ -2,11 +2,8 @@ import { fixture, expect, waitUntil } from '@open-wc/testing';
 import '../src/pb-autocomplete.js';
 import '../src/pb-page.js';
 import '@polymer/paper-item';
+import '@polymer/iron-form';
 
-
-function serializeForm(form) {
-    return new URLSearchParams(new FormData(form)).toString();
-}
 
 describe('simple autocomplete with static suggestions', () => {
     it('submits in form', async () => {
@@ -17,17 +14,19 @@ describe('simple autocomplete with static suggestions', () => {
         const el = (
             await fixture(`
                 <pb-page endpoint=".">
-                    <form action="">
-                        <pb-autocomplete name="lang" placeholder="Language" value="pl" icon="icons:flag"
-                            suggestions='[{"text": "English", "value": "en"}, {"text": "Polish", "value": "pl"}, {"text": "German", "value": "de"}]'>
-                        </pb-autocomplete>
-                    </form>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-autocomplete name="lang" placeholder="Language" value="pl" icon="icons:flag"
+                                suggestions='[{"text": "English", "value": "en"}, {"text": "Polish", "value": "pl"}, {"text": "German", "value": "de"}]'>
+                            </pb-autocomplete>
+                        </form>
+                    </iron-form>
                 </pb-page>
             `)
         );
         await waitUntil(() => initDone);
 
-        const form = el.querySelector('form');
-        expect(serializeForm(form)).to.equal('lang=pl');
+        const form = el.querySelector('iron-form');
+        expect(form.serializeForm()).to.deep.equal({'lang': 'pl'});
     });
 });

--- a/test/pb-i18n.test.js
+++ b/test/pb-i18n.test.js
@@ -28,7 +28,7 @@ describe('translate labels', () => {
         expect(node._translated).to.equal('Found 10 items');
 
         node = el.querySelector('pb-i18n[key="undefined"]');
-        expect(node._translated).to.be.undefined;
+        expect(node._translated).to.be.null;
 
         node = el.querySelector('a');
         expect(node.title).to.equal('Download');
@@ -72,18 +72,18 @@ describe('translate labels', () => {
         );
         await waitUntil(() => initDone);
 
-        const span = el.querySelector('span');
+        const span = el.querySelector('span[data-i18n]');
         expect(span).to.have.text('Custom Table of Contents');
 
         let i18n = el.querySelector('pb-i18n[key="demo.message"]');
-        expect(i18n.shadowRoot).to.have.text('User defined message');
+        expect(i18n).to.have.text('User defined message');
 
         // app_en does not overwrite document.normalized - should fall back to default
         i18n = el.querySelector('pb-i18n[key="document.normalized"]');
-        expect(i18n.shadowRoot).to.have.text('Normalized View');
+        expect(i18n).to.have.text('Normalized View');
 
         i18n = el.querySelector('pb-i18n[key="mycomponent.info"]');
-        expect(i18n.shadowRoot).to.have.text('An information coming from a custom component');
+        expect(i18n).to.have.text('An information coming from a custom component');
     });
 
     it('translates to German', async () => {
@@ -103,17 +103,17 @@ describe('translate labels', () => {
         );
         await waitUntil(() => initDone);
 
-        const span = el.querySelector('span');
+        const span = el.querySelector('span[data-i18n]');
         expect(span).to.have.text('Inhaltsverzeichnis angepasst');
 
         let i18n = el.querySelector('pb-i18n[key="demo.message"]');
-        expect(i18n.shadowRoot).to.have.text('Benutzerdefinierte Nachricht');
+        expect(i18n).to.have.text('Benutzerdefinierte Nachricht');
 
         // app_en does not overwrite document.normalized - should fall back to default
         i18n = el.querySelector('pb-i18n[key="document.normalized"]');
-        expect(i18n.shadowRoot).to.have.text('Normalisierte Ansicht');
+        expect(i18n).to.have.text('Normalisierte Ansicht');
 
         i18n = el.querySelector('pb-i18n[key="mycomponent.info"]');
-        expect(i18n.shadowRoot).to.have.text('Informationen einer Erweiterungskomponente');
+        expect(i18n).to.have.text('Informationen einer Erweiterungskomponente');
     });
 });

--- a/test/pb-select.test.js
+++ b/test/pb-select.test.js
@@ -2,11 +2,10 @@ import { fixture, expect, waitUntil } from '@open-wc/testing';
 import '../src/pb-select.js';
 import '../src/pb-page.js';
 import '@polymer/paper-item';
+import '@polymer/iron-form';
 
 
-function serializeForm(form) {
-    return new URLSearchParams(new FormData(form)).toString();
-}
+
 
 describe('simple select', () => {
     it('submits in form', async () => {
@@ -17,29 +16,31 @@ describe('simple select', () => {
         const el = (
             await fixture(`
                 <pb-page endpoint=".">
-                    <form action="">
-                        <pb-select label="Dinosaurs" name="key" value="1">
-                            <paper-item></paper-item>
-                            <paper-item value="0">Item 0</paper-item>
-                            <paper-item value="1">Item 1</paper-item>
-                            <paper-item value="2">Item 2</paper-item>
-                            <paper-item value="3">Item 3</paper-item>
-                        </pb-select>
-                    </form>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-select label="Dinosaurs" name="key" value="1">
+                                <paper-item></paper-item>
+                                <paper-item value="0">Item 0</paper-item>
+                                <paper-item value="1">Item 1</paper-item>
+                                <paper-item value="2">Item 2</paper-item>
+                                <paper-item value="3">Item 3</paper-item>
+                            </pb-select>
+                        </form>
+                    </iron-form>
                 </pb-page>
             `)
         );
         await waitUntil(() => initDone);
         
-        const form = el.querySelector('form');
+        const form = el.querySelector('iron-form');
         const select = el.querySelector('pb-select');
 
-        expect(serializeForm(form)).to.equal('key=1');
+        expect(form.serializeForm()).to.deep.equal({'key': '1'});
         expect(select.value).to.equal('1');
 
         select.value = "2";
         await select.updateComplete;
-        expect(serializeForm(form)).to.equal('key=2');
+        expect(form.serializeForm()).to.deep.equal({'key': '2'});
     });
     it('supports multiple selection', async () => {
         let initDone;
@@ -49,29 +50,32 @@ describe('simple select', () => {
         const el = (
             await fixture(`
                 <pb-page endpoint=".">
-                    <form action="">
-                        <pb-select label="Items" name="key" values='["1"]' multi>
-                            <paper-item></paper-item>
-                            <paper-item value="0">Item 0</paper-item>
-                            <paper-item value="1">Item 1</paper-item>
-                            <paper-item value="2">Item 2</paper-item>
-                            <paper-item value="3">Item 3</paper-item>
-                        </pb-select>
-                    </form>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-select label="Items" name="key" values='["1"]' multi>
+                                <paper-item></paper-item>
+                                <paper-item value="0">Item 0</paper-item>
+                                <paper-item value="1">Item 1</paper-item>
+                                <paper-item value="2">Item 2</paper-item>
+                                <paper-item value="3">Item 3</paper-item>
+                            </pb-select>
+                        </form>
+                    <iron-form id="form">
                 </pb-page>
             `)
         );
         await waitUntil(() => initDone);
 
-        const form = el.querySelector('form');
+        const form = el.querySelector('iron-form');
         const select = el.querySelector('pb-select');
-        expect(serializeForm(form)).to.equal('key=1');
+        expect(form.serializeForm()).to.deep.equal({'key': '[1]'});
         expect(select.values).to.deep.equal(['1']);
 
         select.values = ["2", "3"];
         await select.updateComplete;
         expect(select.values).to.deep.equal(['2', '3']);
-        expect(serializeForm(form)).to.equal('key=2&key=3');
+        
+        expect(form.serializeForm()).to.deep.equal({'key': '[2, 3]'});
     });
 });
 
@@ -84,9 +88,11 @@ describe('select initialized from remote data source', () => {
         const el = (
             await fixture(`
                 <pb-page endpoint=".">
-                    <form action="">
-                        <pb-select label="Language" name="lang" value="de" source="demo/select.json"></pb-select>
-                    </form>
+                    <iron-form id="form">
+                        <form action="">
+                            <pb-select label="Language" name="lang" value="de" source="demo/select.json"></pb-select>
+                        </form>
+                    </iron-form>
                 </pb-page>
             `)
         );
@@ -95,11 +101,11 @@ describe('select initialized from remote data source', () => {
         const select = el.querySelector('pb-select');
         await waitUntil(() => select._items.length > 0);
         
-        const form = el.querySelector('form');
-        expect(serializeForm(form)).to.equal('lang=de');
+        const form = el.querySelector('iron-form');
+        expect(form.serializeForm()).to.deep.equal({'lang': 'de'});
 
         select.value = "en";
         await select.updateComplete;
-        expect(serializeForm(form)).to.equal('lang=en');
+        expect(form.serializeForm()).to.deep.equal({'lang': 'en'});
     });
 });

--- a/test/pb-select.test.js
+++ b/test/pb-select.test.js
@@ -1,4 +1,4 @@
-import { fixture, expect, waitUntil } from '@open-wc/testing';
+import { fixture, expect, waitUntil, oneEvent } from '@open-wc/testing';
 import '../src/pb-select.js';
 import '../src/pb-page.js';
 import '@polymer/paper-item';
@@ -68,14 +68,40 @@ describe('simple select', () => {
 
         const form = el.querySelector('iron-form');
         const select = el.querySelector('pb-select');
-        expect(form.serializeForm()).to.deep.equal({'key': '[1]'});
+        expect(form.serializeForm()).to.deep.equal({'key': "1"});
         expect(select.values).to.deep.equal(['1']);
 
         select.values = ["2", "3"];
         await select.updateComplete;
         expect(select.values).to.deep.equal(['2', '3']);
         
-        expect(form.serializeForm()).to.deep.equal({'key': '[2, 3]'});
+        expect(form.serializeForm()).to.deep.equal({'key': ["2", "3"]});
+    });
+    it('works in standard HTML form', async () => {
+        let initDone;
+        document.addEventListener('pb-page-ready', () => {
+            initDone = true;
+        });
+        const el = (
+            await fixture(`
+                <pb-page endpoint=".">
+                    <form action="" id="form">
+                        <pb-select label="Items" name="key" values='["1", "2"]' multi>
+                            <paper-item></paper-item>
+                            <paper-item value="0">Item 0</paper-item>
+                            <paper-item value="1">Item 1</paper-item>
+                            <paper-item value="2">Item 2</paper-item>
+                            <paper-item value="3">Item 3</paper-item>
+                        </pb-select>
+                    </form>
+                </pb-page>
+            `)
+        );
+        await waitUntil(() => initDone);
+
+        const form = el.querySelector('form');
+        const data = new URLSearchParams(new FormData(form)).toString();
+        expect(data).to.equal('key=1&key=2');
     });
 });
 


### PR DESCRIPTION
`pb-page` sends a `pb-i18n-update` event when translations become available. This event was used to set the singleton translation function for the lit-html parts as well as trigger `pb-i18n` to update. However, the latter requires that the translation function is already set, and because there is no guarantee in which sequence event listeners are processed, the function may still have been undefined when the event reached `pb-i18n`. Solution: `pb-page` now explicitely sets the translation function singleton **before** it triggers the event. This way - whoever receives the event next - can be sure there's a translation function already set.

The PR also addresses an issue with `pb-i18n` translations being used in the options passed to `pb-select`: `paper-dropdown-menu` uses the text content of each item to display the current selection. But since `pb-i18n` kept the translated text in its shadow DOM, the light DOM text content was always the original, untranslated value. Solution: change `pb-i18n` to not use shadow DOM. It is unnecessary for an element only containing text.