### PR TITLE
dropdown uses full with of pb-select

### DIFF
--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -221,6 +221,9 @@ export class PbSelect extends pbMixin(LitElement) {
                 font-weight: 400;
                 color: var(--pb-color-lighter);
             }
+            paper-dropdown-menu-light{
+                width:100%;            
+            }
         `;
     }
 }


### PR DESCRIPTION
without the rule the dropdown won't stretch to full width of component size