### PR TITLE
fixes unwanted null values with multiple select

### DIFF
--- a/demo/pb-select.html
+++ b/demo/pb-select.html
@@ -10,77 +10,109 @@
         <!--scripts-->
         <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js" defer></script>
         <script type="module" src="../node_modules/@polymer/paper-button/paper-button.js"></script>
+        <script type="module" src="../node_modules/@polymer/iron-form/iron-form.js"></script>
         <script type="module" src="../src/pb-page.js"></script>
         <script type="module" src="../src/pb-select.js"></script>
         <script type="module" src="../src/pb-lang.js"></script>
         <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
         <!--/scripts-->
+        <style>
+            pb-select {
+                width: 200px;
+            }
+        </style>
     </head>
     <body>
         <h1>Using pb-select</h1>
-        
+
         <pb-demo-snippet>
             <template>
                 <pb-page locales="../i18n/{{ns}}/{{lng}}.json" endpoint="http://localhost:8080/exist/apps/tei-publisher">
-                    <form id="form" action="">
-                        <p>Single item selection:</p>
-                        <pb-select label="language" name="lang1" value="es">
-                            <paper-item value="bg">Български</paper-item>
-                            <paper-item value="cs">český</paper-item>
-                            <paper-item value="de">Deutsch</paper-item>
-                            <paper-item value="en">English</paper-item>
-                            <paper-item value="es">Español</paper-item>
-                            <paper-item value="el">ελληνικά</paper-item>
-                            <paper-item value="fr">Français</paper-item>
-                            <paper-item value="it">Italiano</paper-item>
-                            <paper-item value="ka">ქართული</paper-item>
-                            <paper-item value="nl">Nederlands</paper-item>
-                            <paper-item value="no">Norsk</paper-item>
-                            <paper-item value="pl">Polski</paper-item>
-                            <paper-item value="pt">Português</paper-item>
-                            <paper-item value="ro">Română</paper-item>
-                            <paper-item value="ru">русский</paper-item>
-                            <paper-item value="sl">Slovenščina</paper-item>
-                            <paper-item value="sv">Svenska</paper-item>
-                            <paper-item value="tr">Türkçe</paper-item>
-                            <paper-item value="uk">Українська</paper-item>
-                        </pb-select>
-                        <p>with option "multi":</p>
-                        <pb-select label="language" name="lang2" values='["fr", "de"]' multi>
-                            <paper-item value="bg">Български</paper-item>
-                            <paper-item value="cs">český</paper-item>
-                            <paper-item value="de">Deutsch</paper-item>
-                            <paper-item value="en">English</paper-item>
-                            <paper-item value="es">Español</paper-item>
-                            <paper-item value="el">ελληνικά</paper-item>
-                            <paper-item value="fr">Français</paper-item>
-                            <paper-item value="it">Italiano</paper-item>
-                            <paper-item value="ka">ქართული</paper-item>
-                            <paper-item value="nl">Nederlands</paper-item>
-                            <paper-item value="no">Norsk</paper-item>
-                            <paper-item value="pl">Polski</paper-item>
-                            <paper-item value="pt">Português</paper-item>
-                            <paper-item value="ro">Română</paper-item>
-                            <paper-item value="ru">русский</paper-item>
-                            <paper-item value="sl">Slovenščina</paper-item>
-                            <paper-item value="sv">Svenska</paper-item>
-                            <paper-item value="tr">Türkçe</paper-item>
-                            <paper-item value="uk">Українська</paper-item>
-                        </pb-select>
-                        <button type="submit"><paper-button>Submit</paper-button></button>
-                    </form>
+                    <iron-form id="ironform">
+                        <form id="form" action="">
+                            <p>Single item selection:</p>
+                            <pb-select label="language" name="lang1" value="en">
+                                <paper-item value="bg">Български</paper-item>
+                                <paper-item value="cs">český</paper-item>
+                                <paper-item value="de">Deutsch</paper-item>
+                                <paper-item value="en">English</paper-item>
+                                <paper-item value="es">Español</paper-item>
+                                <paper-item value="el">ελληνικά</paper-item>
+                                <paper-item value="fr">Français</paper-item>
+                                <paper-item value="it">Italiano</paper-item>
+                                <paper-item value="ka">ქართული</paper-item>
+                                <paper-item value="nl">Nederlands</paper-item>
+                                <paper-item value="no">Norsk</paper-item>
+                                <paper-item value="pl">Polski</paper-item>
+                                <paper-item value="pt">Português</paper-item>
+                                <paper-item value="ro">Română</paper-item>
+                                <paper-item value="ru">русский</paper-item>
+                                <paper-item value="sl">Slovenščina</paper-item>
+                                <paper-item value="sv">Svenska</paper-item>
+                                <paper-item value="tr">Türkçe</paper-item>
+                                <paper-item value="uk">Українська</paper-item>
+                            </pb-select>
+                            <p>Single item selection without preselect:</p>
+                            <pb-select label="language" name="lang2" value="">
+                                <paper-item></paper-item>
+                                <paper-item value="bg">Български</paper-item>
+                                <paper-item value="cs">český</paper-item>
+                                <paper-item value="de">Deutsch</paper-item>
+                                <paper-item value="en">English</paper-item>
+                                <paper-item value="es">Español</paper-item>
+                                <paper-item value="el">ελληνικά</paper-item>
+                                <paper-item value="fr">Français</paper-item>
+                                <paper-item value="it">Italiano</paper-item>
+                                <paper-item value="ka">ქართული</paper-item>
+                                <paper-item value="nl">Nederlands</paper-item>
+                                <paper-item value="no">Norsk</paper-item>
+                                <paper-item value="pl">Polski</paper-item>
+                                <paper-item value="pt">Português</paper-item>
+                                <paper-item value="ro">Română</paper-item>
+                                <paper-item value="ru">русский</paper-item>
+                                <paper-item value="sl">Slovenščina</paper-item>
+                                <paper-item value="sv">Svenska</paper-item>
+                                <paper-item value="tr">Türkçe</paper-item>
+                                <paper-item value="uk">Українська</paper-item>
+                            </pb-select>
+                            <p>with option "multi":</p>
+                                <pb-select label="language" name="lang3" value='["fr", "de"]' multi>
+                                <paper-item value="bg">Български</paper-item>
+                                <paper-item value="cs">český</paper-item>
+                                <paper-item value="de">Deutsch</paper-item>
+                                <paper-item value="en">English</paper-item>
+                                <paper-item value="es">Español</paper-item>
+                                <paper-item value="el">ελληνικά</paper-item>
+                                <paper-item value="fr">Français</paper-item>
+                                <paper-item value="it">Italiano</paper-item>
+                                <paper-item value="ka">ქართული</paper-item>
+                                <paper-item value="nl">Nederlands</paper-item>
+                                <paper-item value="no">Norsk</paper-item>
+                                <paper-item value="pl">Polski</paper-item>
+                                <paper-item value="pt">Português</paper-item>
+                                <paper-item value="ro">Română</paper-item>
+                                <paper-item value="ru">русский</paper-item>
+                                <paper-item value="sl">Slovenščina</paper-item>
+                                <paper-item value="sv">Svenska</paper-item>
+                                <paper-item value="tr">Türkçe</paper-item>
+                                <paper-item value="uk">Українська</paper-item>
+                            </pb-select>
+                            <button type="submit"><paper-button>Submit</paper-button></button>
+                        </form>
+                    </iron-form>
                     <p>Parameters which would be sent: <code id="output"></code></p>
                 </pb-page>
                 <script>
-                    const form = document.getElementById('form');
+                    const form = document.getElementById('ironform');
                     form.addEventListener('submit', (ev) => {
-                        ev.preventDefault();
-                        const data = new URLSearchParams(new FormData(form)).toString();
+                        console.log('form data ', form.serializeForm());
+                        const data = new URLSearchParams(form.serializeForm());
+                        console.log('UrlSearchParams ', data);
                         document.getElementById('output').innerHTML = data;
                     });
                 </script>
             </template>
         </pb-demo-snippet>
-       
+
     </body>
 </html>

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -9,7 +9,7 @@ import { pbMixin } from './pb-mixin.js';
 
 /**
  * Replacement for an HTML select element with additional features:
- * 
+ *
  * 1. item list can be loaded from remote endpoint via AJAX
  * 2. may contain additional nested form in the slot
  *    named `subform`, whose values will be sent with the AJAX request
@@ -197,7 +197,7 @@ export class PbSelect extends pbMixin(LitElement) {
         if (this.multi) {
             this._selected = list.selectedValues;
             this.values = this._selected;
-            this.value = null;
+            this.value = undefined;
         } else {
             this._selected = [list.selected];
             this.value = list.selected;


### PR DESCRIPTION
when selecting values from pb-select multiple an unwanted 'null' value was created in formData.

Using 'undefined' instead fixes the issue.