### PR TITLE
fixed serialization of pb-select multi: removed 'null' from url if no…

### DIFF
--- a/demo/pb-search2.html
+++ b/demo/pb-search2.html
@@ -59,6 +59,12 @@
                             <paper-item value="tei-text">In text</paper-item>
                             <paper-item value="tei-head">In headings</paper-item>
                         </pb-select>
+                        <pb-select label="multi select" name="multi-target"  multi="multi">
+                            <paper-item value=""></paper-item>
+                            <paper-item value="tei-text">In text</paper-item>
+                            <paper-item value="tei-head">In headings</paper-item>
+                        </pb-select>
+
                     <pb-paginate per-page="10" range="5"></pb-paginate>
                     <pb-load url="templates/search-results.html"></pb-load>
                 </main>

--- a/src/pb-mixin.js
+++ b/src/pb-mixin.js
@@ -401,14 +401,25 @@ export const pbMixin = (superclass) => class PbMixin extends superclass {
     }
 
     setParameter(name, value) {
-        if (typeof value === 'undefined') {
+        // console.log("pb-mixin: setParameter - name: ", name, " - value: ", value);
+        if (typeof value === 'undefined' || value === null) {
             TeiPublisher.url.searchParams.delete(name);
         } else if (Array.isArray(value)) {
+            // console.log("setParameter: isArray - name: ", name, " is array");
             TeiPublisher.url.searchParams.delete(name);
             value.forEach(function (val) {
                 TeiPublisher.url.searchParams.append(name, val);
             });
+        } else if((typeof value === 'string' || value instanceof String)  &&  value.startsWith("[")) {
+            // console.log("setParameter - name: ", name, " is a string, starting with [");
+            TeiPublisher.url.searchParams.delete(name);
+            const valueArray = value.substring(1,value.length-1).split(",")
+            valueArray.forEach(function (val) {
+                // console.log("setParameter - name: ", name, " - value: ", val.trim());
+                TeiPublisher.url.searchParams.append(name, val.trim());
+            });
         } else {
+            // console.log("setParameter - name: ", name, " - value: ", value);
             TeiPublisher.url.searchParams.set(name, value);
         }
     }


### PR DESCRIPTION
… value is selected, and &name=[val1,val2] is now added as &nanme=val1&nanme=val2