### PR TITLE
feat(pb-search) add submit and reset to form for accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ css/
 dist
 build
 lib/
+*.iml

--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -97,6 +97,8 @@
     "requiredGroup": "must be member of group {{group}}"
   },
   "search": {
+    "search":"Search",
+    "reset": "Reset",
     "placeholder": "Enter Query",
     "sections": "Search sections",
     "headings": "Search headings"

--- a/src/pb-search.js
+++ b/src/pb-search.js
@@ -104,6 +104,12 @@ export class PbSearch extends pbMixin(LitElement) {
                     <paper-autocomplete-suggestions id="autocomplete" for="search" source="${this._suggestions}" remote-source></paper-autocomplete-suggestions>
                     <slot></slot>
                     <input type="hidden" name="doc">
+                    
+                    <div>
+                        <paper-button id="submit" raised="raised" @click="${this._doSearch}">${translate('search.search')}</paper-button>
+                        <a href="#" id="reset" @click="${this._reset}">${translate('search.reset')}</a>
+                    </div>
+
                 </form>
             </iron-form>
             <iron-ajax
@@ -123,6 +129,9 @@ export class PbSearch extends pbMixin(LitElement) {
                 --paper-input-container-color: var(--pb-search-label-color, var(--paper-grey-500, #303030));
                 --paper-input-container-input-color: var(--pb-search-input-color, var(--pb-color-primary, #000000));
                 --paper-input-container-focus-color: var(--pb-search-focus-color, var(--paper-grey-500, #303030));
+            }
+            a{
+                padding:1rem;
             }
         `;
     }
@@ -151,6 +160,10 @@ export class PbSearch extends pbMixin(LitElement) {
 
     _doSubmit() {
         this.shadowRoot.getElementById('ironform').submit();
+    }
+
+    _reset(){
+        this.shadowRoot.getElementById('ironform').reset();
     }
 
     _autocomplete(ev) {


### PR DESCRIPTION
a search form should have a 'search' and 'reset' trigger for accessibility reasons even if the form can be submitted by other means.

This PR adds a `<paper-button>` as submit plus an `<a>` for the reset (for visual hierarchy) to the shadowDom of the form. 

It's placed in shadowDom to ensure these elements are always present and occur at the end of the form. 

2 i18n keys have been created in en.json but are missing in the other language files. 

