### PR TITLE
fix(pb-select) default sizing for multi

### DIFF
--- a/demo/pb-search3.html
+++ b/demo/pb-search3.html
@@ -1,0 +1,88 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-search multi Demo</title>
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-fab/paper-fab.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-load.js"></script>
+    <script type="module" src="../src/pb-search.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <script type="module" src="../src/pb-progress.js"></script>
+    <script type="module" src="../src/pb-i18n.js"></script>
+    <script type="module" src="../src/pb-select.js"></script>
+
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style>
+            pb-search {
+                display: block;
+                --pb-search-label-color: var(--paper-grey-500, #e0e0e0);
+                --pb-search-input-color: var(--paper-grey-900, #202020);
+                --pb-search-focus-color: var(--paper-orange-500);
+            }
+            pb-progress {
+                margin-bottom: 20px;
+            }
+            pb-paginate {
+                margin-top: 40px;
+                margin-bottom: 10px;
+            }
+            pb-load {
+                height: 60vh;
+                overflow: auto;
+            }
+            #results header {
+                display: flex;
+                background-color: #F0F0F0;
+            }
+
+            #results header .count {
+                margin-right: 10px;
+            }
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
+                <pb-progress></pb-progress>
+                <main>
+                    <pb-search id="search-form">
+                        <pb-select label="language" name="lang" value="en" multi="multi">
+                            <paper-item value="bg">Български</paper-item>
+                            <paper-item value="cs">český</paper-item>
+                            <paper-item value="de">Deutsch</paper-item>
+                            <paper-item value="en">English</paper-item>
+                            <paper-item value="es">Español</paper-item>
+                            <paper-item value="el">ελληνικά</paper-item>
+                            <paper-item value="fr">Français</paper-item>
+                            <paper-item value="it">Italiano</paper-item>
+                            <paper-item value="ka">ქართული</paper-item>
+                            <paper-item value="nl">Nederlands</paper-item>
+                            <paper-item value="no">Norsk</paper-item>
+                            <paper-item value="pl">Polski</paper-item>
+                            <paper-item value="pt">Português</paper-item>
+                            <paper-item value="ro">Română</paper-item>
+                            <paper-item value="ru">русский</paper-item>
+                            <paper-item value="sl">Slovenščina</paper-item>
+                            <paper-item value="sv">Svenska</paper-item>
+                            <paper-item value="tr">Türkçe</paper-item>
+                            <paper-item value="uk">Українська</paper-item>
+                        </pb-select>
+                    </pb-search>
+                    <pb-paginate per-page="10" range="5"></pb-paginate>
+                    <pb-load url="templates/search-results.html"></pb-load>
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -251,8 +251,10 @@ export class PbSelect extends pbMixin(LitElement) {
                 display: block;
                 position:relative;
                 overflow:auto;
-                height:16rem;
                 margin-top:1rem;
+            }
+            :host([multi]) paper-listbox{
+                height:16rem;
             }
 
             iron-label {

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -251,6 +251,8 @@ export class PbSelect extends pbMixin(LitElement) {
                 display: block;
                 position:relative;
                 overflow:auto;
+                height:16rem;
+                margin-top:1rem;
             }
 
             iron-label {


### PR DESCRIPTION
without default size multi selects will take huge space. Can be overwritten by user.

New demo file shows multi select with scrolling