### PR TITLE
feat(pb-search) slots for 'search' + 'reset' controls

### DIFF
--- a/demo/pb-search3.html
+++ b/demo/pb-search3.html
@@ -1,0 +1,88 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-search multi Demo</title>
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-fab/paper-fab.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-load.js"></script>
+    <script type="module" src="../src/pb-search.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <script type="module" src="../src/pb-progress.js"></script>
+    <script type="module" src="../src/pb-i18n.js"></script>
+    <script type="module" src="../src/pb-select.js"></script>
+
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style>
+            pb-search {
+                display: block;
+                --pb-search-label-color: var(--paper-grey-500, #e0e0e0);
+                --pb-search-input-color: var(--paper-grey-900, #202020);
+                --pb-search-focus-color: var(--paper-orange-500);
+            }
+            pb-progress {
+                margin-bottom: 20px;
+            }
+            pb-paginate {
+                margin-top: 40px;
+                margin-bottom: 10px;
+            }
+            pb-load {
+                height: 60vh;
+                overflow: auto;
+            }
+            #results header {
+                display: flex;
+                background-color: #F0F0F0;
+            }
+
+            #results header .count {
+                margin-right: 10px;
+            }
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
+                <pb-progress></pb-progress>
+                <main>
+                    <pb-search id="search-form">
+                        <pb-select label="language" name="lang" value="en" multi="multi">
+                            <paper-item value="bg">Български</paper-item>
+                            <paper-item value="cs">český</paper-item>
+                            <paper-item value="de">Deutsch</paper-item>
+                            <paper-item value="en">English</paper-item>
+                            <paper-item value="es">Español</paper-item>
+                            <paper-item value="el">ελληνικά</paper-item>
+                            <paper-item value="fr">Français</paper-item>
+                            <paper-item value="it">Italiano</paper-item>
+                            <paper-item value="ka">ქართული</paper-item>
+                            <paper-item value="nl">Nederlands</paper-item>
+                            <paper-item value="no">Norsk</paper-item>
+                            <paper-item value="pl">Polski</paper-item>
+                            <paper-item value="pt">Português</paper-item>
+                            <paper-item value="ro">Română</paper-item>
+                            <paper-item value="ru">русский</paper-item>
+                            <paper-item value="sl">Slovenščina</paper-item>
+                            <paper-item value="sv">Svenska</paper-item>
+                            <paper-item value="tr">Türkçe</paper-item>
+                            <paper-item value="uk">Українська</paper-item>
+                        </pb-select>
+                    </pb-search>
+                    <pb-paginate per-page="10" range="5"></pb-paginate>
+                    <pb-load url="templates/search-results.html"></pb-load>
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>

--- a/demo/pb-search3.html
+++ b/demo/pb-search3.html
@@ -54,6 +54,7 @@
             <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
                 <pb-progress></pb-progress>
                 <main>
+                    <h2>multi-select</h2>
                     <pb-search id="search-form">
                         <pb-select label="language" name="lang" value="en" multi="multi">
                             <paper-item value="bg">Български</paper-item>

--- a/demo/pb-search4.html
+++ b/demo/pb-search4.html
@@ -1,0 +1,58 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-search Demo</title>
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-checkbox/paper-checkbox.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-load.js"></script>
+    <script type="module" src="../src/pb-search.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <script type="module" src="../src/pb-progress.js"></script>
+    <script type="module" src="../src/pb-i18n.js"></script>
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style>
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher">
+                <pb-progress></pb-progress>
+                <main>
+                    <h2>without buttons</h2>
+
+                    <pb-search id="search-form">
+                    </pb-search>
+
+                    <h2>paper buttons for search + reset</h2>
+
+                    <pb-search id="search-form">
+                        <paper-button slot="searchButton">submit</paper-button>
+                        <paper-button slot="resetButton">reset</paper-button>
+                    </pb-search>
+
+                    <h2>native buttons for search + reset</h2>
+                    <pb-search id="search-form2">
+                        <button slot="searchButton">submit</button>
+                        <button slot="resetButton">reset</button>
+                    </pb-search>
+
+
+                    <pb-paginate per-page="10" range="5"></pb-paginate>
+                    <pb-load url="templates/search-results.html"></pb-load>
+
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>

--- a/src/pb-search.js
+++ b/src/pb-search.js
@@ -89,8 +89,6 @@ export class PbSearch extends pbMixin(LitElement) {
         const childNodes = slot.assignedNodes({flatten: true});
         childNodes.forEach(c => {
             if(c.slot === slotName){
-                console.log('register', c);
-                console.log('this ', this);
                 c.addEventListener('click', func);
             }
         });

--- a/src/pb-search.js
+++ b/src/pb-search.js
@@ -4,6 +4,7 @@ import { translate } from "./pb-i18n.js";
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/iron-ajax';
 import '@polymer/iron-form';
+import '@polymer/paper-button';
 import '@polymer/iron-icon';
 import '@cwmr/paper-autocomplete';
 
@@ -77,6 +78,23 @@ export class PbSearch extends pbMixin(LitElement) {
                 "params": params
             });
         }
+
+        this._attachButton('searchButton',(e) => this._doSearch(e));
+        this._attachButton('resetButton',() => this._reset());
+
+    }
+
+    _attachButton(slotName,func){
+        const slot = this.shadowRoot.querySelector('slot[name="' + slotName + '"]');
+        const childNodes = slot.assignedNodes({flatten: true});
+        childNodes.forEach(c => {
+            if(c.slot === slotName){
+                console.log('register', c);
+                console.log('this ', this);
+                c.addEventListener('click', func);
+            }
+        });
+
     }
 
     render() {
@@ -104,11 +122,9 @@ export class PbSearch extends pbMixin(LitElement) {
                     <slot></slot>
                     <input type="hidden" name="doc">
                     
-                    <div class="buttons">
-                        <paper-button id="submit" raised="raised" @click="${this._doSearch}">${translate('search.search')}</paper-button>
-                        <a href="#" id="reset" @click="${this._reset}">${translate('search.reset')}</a>
-                    </div>
-
+                    <slot name="searchButton"></slot>
+                    <slot name="resetButton"></slot>
+                    
                 </form>
             </iron-form>
             <iron-ajax
@@ -138,14 +154,14 @@ export class PbSearch extends pbMixin(LitElement) {
         `;
     }
 
-    _doSearch(ev) {
+    _doSearch() {
         const json = this.shadowRoot.getElementById('ironform').serializeForm();
         // always start on first result after submitting new search
         json.start = 1;
         this.setParameters(json);
         if (this.redirect) {
             window.location.href = this.action + TeiPublisher.url.search;
-        } else {                        
+        } else {
             this.pushHistory('search');
             this.emitTo('pb-load', {
                 "url": this.action,

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -251,8 +251,10 @@ export class PbSelect extends pbMixin(LitElement) {
                 display: block;
                 position:relative;
                 overflow:auto;
-                height:16rem;
                 margin-top:1rem;
+            }
+            :host([multi]) paper-listbox{
+                height:16rem;
             }
 
             iron-label {

--- a/src/pb-select.js
+++ b/src/pb-select.js
@@ -251,6 +251,8 @@ export class PbSelect extends pbMixin(LitElement) {
                 display: block;
                 position:relative;
                 overflow:auto;
+                height:16rem;
+                margin-top:1rem;
             }
 
             iron-label {


### PR DESCRIPTION
support slots for 'search' and 'reset' controls.

This allows to create a pb-search:
* without any buttons (default)
* with native buttons
* with paper-buttons
* other elements that support the 'click' event.

Demo file (pb-search4.html) included