### PR TITLE
Align icon in pb-collapse with other non-collapsed pb-list items (i.e. in a TOC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.3.0](https://github.com/eeditiones/tei-publisher-components/compare/v1.2.4...v1.3.0) (2020-09-07)
+
+
+### Features
+
+* **pb-popover:** emit pb-popover-show event ([d914035](https://github.com/eeditiones/tei-publisher-components/commit/d91403571c8d0827788ee8e119d910407492b27f))
+
 ## [1.2.4](https://github.com/eeditiones/tei-publisher-components/compare/v1.2.3...v1.2.4) (2020-09-03)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teipublisher/pb-components",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teipublisher/pb-components",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Collection of webcomponents underlying TEI Publisher (Work in progress)",
   "repository": "https://github.com/eeditiones/tei-publisher-components.git",
   "main": "index.html",

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -21,7 +21,7 @@ import '@polymer/iron-collapse';
  *
  * @slot collapse-trigger - trigger toggling collapsed content on/off
  * @slot collapse-content - content to be collapsed
- * @cssprop --pb-collapse-icon-padding - 0 10px 0 0
+ * @cssprop [--pb-collapse-icon-padding=0 4px 0 0] - padding in px for the "caret-down" icon left to the collapsible item
  * @fires pb-collapse-open - Fires opening the collapsed section
  */
 export class PbCollapse extends pbMixin(LitElement) {
@@ -162,7 +162,7 @@ export class PbCollapse extends pbMixin(LitElement) {
 
             #trigger iron-icon {
                 display: table-cell;
-                padding: var(--pb-collapse-icon-padding, 0 10px 0 0);
+                padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
             }
 
             slot[name="collapse-trigger"] {


### PR DESCRIPTION
#### Before
<img width="147" alt="Screenshot 2020-09-28 at 17 05 49" src="https://user-images.githubusercontent.com/1157669/94458225-f53c2500-01b5-11eb-9030-97b35e60106b.png">


#### After
<img width="141" alt="Screenshot 2020-09-28 at 17 09 05" src="https://user-images.githubusercontent.com/1157669/94458196-e9506300-01b5-11eb-9f86-cfa77346c11a.png">
