### PR TITLE
Make pb-search collect form data

### DIFF
--- a/demo/pb-search3.html
+++ b/demo/pb-search3.html
@@ -18,6 +18,7 @@
     <script type="module" src="../src/pb-progress.js"></script>
     <script type="module" src="../src/pb-i18n.js"></script>
     <script type="module" src="../src/pb-select.js"></script>
+    <script type="module" src="../src/pb-custom-form.js"></script>
 
     <!--/scripts-->
 </head>
@@ -61,31 +62,14 @@
                 <pb-progress></pb-progress>
                 <main>
                     <h2>multi-select</h2>
-                    <pb-search id="search-form">
-                        <pb-select label="language" name="lang" value="en" multi="multi">
-                            <paper-item value="bg">Български</paper-item>
-                            <paper-item value="cs">český</paper-item>
-                            <paper-item value="de">Deutsch</paper-item>
-                            <paper-item value="en">English</paper-item>
-                            <paper-item value="es">Español</paper-item>
-                            <paper-item value="el">ελληνικά</paper-item>
-                            <paper-item value="fr">Français</paper-item>
-                            <paper-item value="it">Italiano</paper-item>
-                            <paper-item value="ka">ქართული</paper-item>
-                            <paper-item value="nl">Nederlands</paper-item>
-                            <paper-item value="no">Norsk</paper-item>
-                            <paper-item value="pl">Polski</paper-item>
-                            <paper-item value="pt">Português</paper-item>
-                            <paper-item value="ro">Română</paper-item>
-                            <paper-item value="ru">русский</paper-item>
-                            <paper-item value="sl">Slovenščina</paper-item>
-                            <paper-item value="sv">Svenska</paper-item>
-                            <paper-item value="tr">Türkçe</paper-item>
-                            <paper-item value="uk">Українська</paper-item>
-                        </pb-select>
-                    </pb-search>
+                    <pb-custom-form id="custom-form">
+                        <input type="text" name="custom">
+                        <button type="submit" slot="searchButton">Submit</button>
+                        <button type="reset" slot="resetButton">Reset</button>
+                    </pb-custom-form>
+                    <pb-search id="search-form" subforms="pb-custom-form"></pb-search>
                     <pb-paginate per-page="10" range="5"></pb-paginate>
-                    <pb-load url="templates/search-results.html"></pb-load>
+                    <pb-load url="api/search"></pb-load>
                 </main>
             </pb-page>
         </template>

--- a/src/pb-browse-docs.js
+++ b/src/pb-browse-docs.js
@@ -84,6 +84,9 @@ export class PbBrowseDocs extends PbLoad {
             group: {
                 type: String
             },
+            subforms: {
+                type: String
+            },
             _file: {
                 type: String
             },
@@ -314,6 +317,7 @@ export class PbBrowseDocs extends PbLoad {
     }
 
     prepareParameters(params) {
+        params = this._paramsFromSubforms(params);
         params.sort = this.sortBy;
         if (this.filter) {
             params.filter = this.filter;
@@ -321,6 +325,17 @@ export class PbBrowseDocs extends PbLoad {
         }
         if (this.facets) {
             params = Object.assign(params, this.facets);
+        }
+        return params;
+    }
+
+    _paramsFromSubforms(params) {
+        if (this.subforms) {
+            document.querySelectorAll(this.subforms).forEach((form) => {
+                if (form.serializeForm) {
+                    Object.assign(params, form.serializeForm());
+                }
+            });
         }
         return params;
     }

--- a/src/pb-custom-form.js
+++ b/src/pb-custom-form.js
@@ -23,13 +23,23 @@ export class PbCustomForm extends PbLoad {
             ev.preventDefault();
             this._submit();
         });
+        this.addEventListener('click', (e) => {
+            if (e.target.slot === 'searchButton'){
+                this.submit();
+            }
+            if (e.target.slot === 'resetButton'){
+                this._reset();
+            }
+        });
     }
 
     render() {
         return html`
             <iron-form id="ironform">
-                <form action="" accept="text/html" method="get">
+                <form action="" accept="text/html" method="GET">
                     <slot></slot>
+                    <slot name="searchButton"></slot>
+                    <slot name="resetButton"></slot>
                 </form>
             </iron-form>
 
@@ -66,8 +76,16 @@ export class PbCustomForm extends PbLoad {
     }
 
     _submit() {
-        const json = this.shadowRoot.getElementById('ironform').serializeForm();
+        const json = this.serializeForm();
         this.emitTo('pb-search-resubmit', { 'params': json });
+    }
+
+    _reset(){
+        this.shadowRoot.getElementById('ironform').reset();
+    }
+    
+    serializeForm() {
+        return this.shadowRoot.getElementById('ironform').serializeForm();
     }
 
     _parseHeaders(xhr) {

--- a/src/pb-load.js
+++ b/src/pb-load.js
@@ -214,6 +214,9 @@ export class PbLoad extends pbMixin(LitElement) {
     }
 
     load(ev) {
+        if (!this.url) {
+            return;
+        }
         if (this.loadOnce && this.loaded) {
             return;
         }

--- a/src/pb-search.js
+++ b/src/pb-search.js
@@ -48,6 +48,9 @@ export class PbSearch extends pbMixin(LitElement) {
             submitOnLoad: {
                 type: Boolean,
                 attribute: 'submit-on-load'
+            },
+            subforms: {
+                type: String
             }
         };
     }
@@ -158,9 +161,10 @@ export class PbSearch extends pbMixin(LitElement) {
     }
 
     _doSearch() {
-        const json = this.shadowRoot.getElementById('ironform').serializeForm();
+        let json = this.shadowRoot.getElementById('ironform').serializeForm();
         // always start on first result after submitting new search
         json.start = 1;
+        json = this._paramsFromSubforms(json);
         this.setParameters(json);
         if (this.redirect) {
             window.location.href = this.action + TeiPublisher.url.search;
@@ -173,8 +177,19 @@ export class PbSearch extends pbMixin(LitElement) {
         }
     }
 
+    _paramsFromSubforms(params) {
+        if (this.subforms) {
+            document.querySelectorAll(this.subforms).forEach((form) => {
+                if (form.serializeForm) {
+                    Object.assign(params, form.serializeForm());
+                }
+            });
+        }
+        return params;
+    }
+
     _handleEnter(e) {
-        if (this.shadowRoot.getElementById('search').value.length != 0 && e.keyCode == 13) {
+        if (e.keyCode === 13) {
             this._doSearch();
         }
     }


### PR DESCRIPTION
from pb-custom-form elements located elsewhere on the page.

Adds a property `subforms` to `pb-search`, containing a CSS selector.