### PR TITLE
Normalize the spelling of "organization"

### DIFF
--- a/i18n/common/de.json
+++ b/i18n/common/de.json
@@ -217,7 +217,7 @@
     "edit": "Annotation ändern",
     "no-properties": "Keine Eigenschaften vorhanden.",
     "occurrences": "Vorkommen im Text",
-    "organisation": "Organisation",
+    "organization": "organization",
     "person": "Person",
     "place": "Ort",
     "term": "Term",

--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -217,7 +217,7 @@
     "save": "Merge and save annotations to TEI",
     "no-properties": "No properties defined.",
     "person": "Person",
-    "organisation": "Organisation",
+    "organization": "organization",
     "place": "Place",
     "term": "Term",
     "date": "Date",

--- a/src/authority/gnd.js
+++ b/src/authority/gnd.js
@@ -38,7 +38,7 @@ export class GND extends Registry {
       case 'term':
         filter = 'SubjectHeading';
         break;
-      case 'organisation':
+      case 'organization':
         filter = 'CorporateBody';
         break;
       default:

--- a/src/authority/kbga.js
+++ b/src/authority/kbga.js
@@ -19,7 +19,7 @@ export class KBGA extends Registry {
               .then(json => {
                 json.data.forEach(item => {
                     
-                    if ((this._register === 'organisation' && item.authority_type !== 'organisation') ||
+                    if ((this._register === 'organization' && item.authority_type !== 'organization') ||
                         (this._register === 'person' && item.authority_type !== 'person')) {
                       return;
                     }
@@ -126,7 +126,7 @@ export class KBGA extends Registry {
       let register;
       switch(this._register) {
         case 'person':
-        case 'organisation':
+        case 'organization':
           register = 'actors';
           break;
         case 'place':


### PR DESCRIPTION
See https://github.com/eeditiones/tei-publisher-app/pull/65.

Please let me know if I should revert/rebase to fix the string for the German spelling.