### PR TITLE
Add Reconciliation Service authority connector (2d try)

### DIFF
--- a/src/authority/connectors.js
+++ b/src/authority/connectors.js
@@ -4,6 +4,7 @@ import { Airtable } from './airtable.js';
 import { GND } from './gnd.js';
 import { KBGA } from './kbga.js';
 import { GF } from './gf.js';
+import { ReconciliationService } from './reconciliation.js';
 import { Custom } from './custom.js';
 
 export function createConnectors(endpoint, root) {
@@ -26,6 +27,9 @@ export function createConnectors(endpoint, root) {
         break;
       case 'GF':
         instance = new GF(configElem);
+        break;
+      case 'ReconciliationService':
+        instance = new ReconciliationService(configElem);
         break;
       case 'Custom':
         instance = new Custom(endpoint, configElem);

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -1,0 +1,124 @@
+/* eslint-disable class-methods-use-this */
+import { Registry } from './registry.js'
+
+// Todo:
+// - strings <- types
+// - use scheme#types in @type output?
+// - test with other providers, inside custom connector
+// - documentation
+
+async function getServiceManifest (endpoint) {
+	const response = await fetch(endpoint);
+	const data = await response.json();
+  return data;
+}
+
+export class ReconciliationService extends Registry {
+  constructor(configElem) {
+    super(configElem)
+    this.endpoint = configElem.getAttribute('endpoint');
+    this.debug = configElem.getAttribute('debug');
+    getServiceManifest(this.endpoint).then((result) => {
+      this.ORConfig = result;
+      if (this.debug) {
+        console.log(
+          'OpenReconcile connector for register \'%s\' at endpoint <%s>. Using config: %o',
+          this._register, this.endpoint, this.ORConfig
+        );
+      }
+    })
+  }
+
+  /**
+   * Query the authority and return a RegistryResult.
+   *
+   * @param {String} key the search string
+   */
+  async query(key) {
+    const results = [];
+    const paramsObj = {
+                        q1: {
+                          query: key
+                        }
+                      };
+
+    return new Promise((resolve) => {
+        fetch(this.endpoint, {
+            method: 'POST',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: "queries=".concat(JSON.stringify(paramsObj))
+        })
+        .then((response) => response.json())
+        .then((json) => {
+            json.q1.result.forEach((item) => {
+              if (this.ORConfig.view) {
+                this.view = this.ORConfig.view.url.replace('{{id}}', item.id);
+              } else {
+                this.view = item.id;
+              }
+              if (item.description) {
+                this.description = item.description;
+              } else if (item.type) {
+                this.description = item.type.map(t => t.name.toString() ).join(', ')
+              } else {
+                this.description = ""
+              }
+              const result = {
+                  register: this._register,
+                  id: (this._prefix ? `${this._prefix}-${item.id}` : item.id),
+                  label: item.name,
+                  link: this.view,
+                  details: this.description,
+                  provider: 'OpenReconcile'
+              };
+              results.push(result);
+            });
+            if (this.debug) {
+              console.log(
+                  'OpenReconcile results: %o',
+                  results
+              );
+            }
+            resolve({
+                totalItems: json.q1.result.length,
+                items: results,
+            });
+        })
+    })
+  }
+
+  /**
+   * Retrieve information about a registry entry and display it
+   * using the given container.
+   *
+   * @param {String} id the id to look up
+   * @param {HTMLElement} container reference to an element which should be used as container for displaying the information
+   * @returns {Promise} a promise
+   */
+  info(id, container) {
+    if (!id) {
+      return Promise.resolve({});
+    }
+    if (!this.ORConfig.preview) {
+      container.innerHTML = 'no \'preview\' information in endpoint\'s manifest';
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      const rawid = this._prefix ? id.substring(this._prefix.length + 1) : id;
+      const url = this.ORConfig.preview.url.replace('{{id}}', encodeURIComponent(rawid));
+      fetch(url)
+      .then(response => response.text())
+      .then((output) => {
+        container.innerHTML = output;
+        resolve({
+          id: this._prefix ? `${this._prefix}-${rawid}` : rawid
+        });
+      })
+      .catch(() => reject());
+    });
+  }
+}


### PR DESCRIPTION
API spec: https://reconciliation-api.github.io/specs/latest/
W3C Community Group: https://www.w3.org/community/reconciliation/ (Some of them are the same people who run lobid at HBZ NRW)

The API is based on OpenRefine's reconciliation function and provides some additional functions such as type-ahead suggestions and more. There is a list of platforms who run a Reconciliation Service API endpoint at https://reconciliation-api.github.io/testbench/.

The Reconciliation Service connector can be used like this:
`<pb-authority connector="ReconciliationService" name="term" prefix="wd" endpoint="https://wikidata.reconci.link/api" debug="debug"/>`

In other words, you define the `endpoint` and a `prefix` and that's it. The `debug` switch gives diagnostic output in the browser console and can be left away. I have tested several lookup providers and it worked well.

Some observations, if these indicate that the request has to be improved before it can be merged, I'd be grateful for some helpful pointers:
- Maybe it'd need a better handling of no good responses - the progress bar of `annotate.html` was running and I wasn't sure if the query would take a long time or if this was already the "no results" situation...
- Also, I could not get it to work inside a custom connector (the lookup worked, but it did not create the register.xml file or, when I copied this over from the playground app, entries within it). Suggestions welcome...
- Finally, I was not sure what information the `strings` key of a result map would have to be filled with, so I left it away. (I piped some information about the type of entity of a result into the `details` key.) 

I have tested like this:

annotate.html:
```
...
    <main>
        <aside class="annotation-editor">
            <div class="toolbar">
                <paper-icon-button id="clear-all" icon="icons:refresh"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.place" title="Place" data-type="place" icon="maps:place" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>

<!-- *** Test here *** -->
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term1" title="Term1" data-type="term1" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term2" title="Term2" data-type="term2" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term3" title="Term3" data-type="term3" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term5" title="Term5" data-type="term5" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term9" title="Term9" data-type="term9" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term0" title="Term0" data-type="term0" icon="icons:loyalty" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"/>
<!-- *** End test *** -->

                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term" title="Term" data-type="term" icon="icons:bookmark" data-shortcut="⌘+⇧+t,ctrl+⇧+t" disabled="disabled"/>
                <paper-icon-button class="annotation-action" data-i18n="[title]annotations.modify" title="Edit" data-type="edit" icon="editor:mode-edit" data-shortcut="⌘+⇧+m,ctrl+⇧+m" disabled="disabled"/>
            </div>

... and further down ...

    <paper-dialog id="authority-dialog">
        <paper-dialog-scrollable>
            <pb-authority-lookup subscribe="transcription" emit="transcription">

<!-- *** Test here *** -->
                <pb-authority connector="ReconciliationService" name="term1" prefix="gtn" endpoint="https://services.getty.edu/vocab/reconcile/" debug="debug"/>
                <pb-authority connector="ReconciliationService" name="term2" prefix="wd" endpoint="https://wikidata.reconci.link/api" debug="debug"/>
                <pb-authority connector="ReconciliationService" name="term3" prefix="lobid" endpoint="https://lobid.org/gnd/reconcile" debug="debug"/>
                <pb-authority connector="ReconciliationService" name="term5" prefix="bbl" endpoint="https://data.biblissima.fr/api/reconcile" debug="debug"/>
                <pb-authority connector="ReconciliationService" name="term9" prefix="bhm" endpoint="https://aleph.occrp.org/api/2/collections/276/reconcile" debug="debug"/>
                <pb-authority connector="Custom" name="term0">
                    <pb-authority connector="ReconciliationService" prefix="custom" endpoint="https://lobid.org/gnd/reconcile" debug="debug"/>
                </pb-authority>
<!-- *** End test *** -->

                <pb-authority connector="Custom" name="organization">
                    <pb-authority connector="GND" prefix="gnd"/>
                </pb-authority>
            </pb-authority-lookup>
```

Next steps for me would be to add documentation to tei-publisher-app, figure out how to handle and report about empty responses from the services, and maybe add a mechanism so that this can be used in the context of the custom authority connector, too.