### PR TITLE
Refactor pb-browse-docs

### DIFF
--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -111,7 +111,9 @@
     "reset": "Reset",
     "placeholder": "Enter Query",
     "sections": "Search sections",
-    "headings": "Search headings"
+    "headings": "Search headings",
+    "title": "Search titles",
+    "content": "Search content"
   },
   "dts": {
     "endpoint": "Select Endpoint",

--- a/src/pb-ajax.js
+++ b/src/pb-ajax.js
@@ -2,9 +2,9 @@ import { LitElement, html, css } from 'lit-element';
 import '@polymer/iron-ajax';
 import '@polymer/paper-dialog';
 import '@polymer/paper-dialog-scrollable';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { pbMixin } from './pb-mixin.js';
-import { translate } from "./pb-i18n.js";
+import { get as i18n } from "./pb-i18n.js";
+import './pb-message.js';
 
 /**
  * Triggers an action on the server and shows a dialog
@@ -14,7 +14,7 @@ import { translate } from "./pb-i18n.js";
  * The parameters sent to the server-side script will be copied
  * from the `pb-view` to which this component subscribes, see pb-update event.
  *
- * @slot - unnamed slot for link text
+ * @slot - unnamed slot for link content
  * @slot title - dialog title
  * 
  * @fires pb-start-update - Fired before the element updates its content
@@ -51,6 +51,19 @@ export class PbAjax extends pbMixin(LitElement) {
             event: {
                 type: String
             },
+            /**
+             * If set, display a confirmation dialog with the message text given in
+             * this property. The user may cancel the action.
+             */
+            confirm: {
+                type: String
+            },
+            /**
+             * Set to not show the server's response
+             */
+            quiet: {
+                type: Boolean
+            },
             _message: {
                 type: String
             }
@@ -60,6 +73,8 @@ export class PbAjax extends pbMixin(LitElement) {
     constructor() {
         super();
         this.method = 'get';
+        this.confirm = null;
+        this.quiet = false;
     }
 
     connectedCallback() {
@@ -78,22 +93,16 @@ export class PbAjax extends pbMixin(LitElement) {
                 with-credentials
                 @error="${this._handleError}"
                 @response="${this._handleResponse}"></iron-ajax>
-            ${this.dialogTemplate}
+            <pb-message id="confirmDialog"></pb-message>
+            <slot name="title" style="display: none"></slot>
         `;
     }
 
-    get dialogTemplate() {
-        return html`
-            <paper-dialog id="messageDialog">
-                <h2><slot name="title">Action</slot></h2>
-                <paper-dialog-scrollable>${unsafeHTML(this._message)}</paper-dialog-scrollable>
-                <div class="buttons">
-                    <paper-button dialog-confirm="dialog-confirm" autofocus="autofocus">
-                    ${translate('dialogs.close')}
-                    </paper-button>
-                </div>
-            </paper-dialog>
-        `;
+    firstUpdated() {
+        super.firstUpdated();
+        const slot = this.shadowRoot.querySelector('slot[name=title]');
+        this._dialogTitle = '';
+        slot.assignedNodes().forEach(node => {this._dialogTitle += node.innerHTML});
     }
 
     static get styles() {
@@ -109,7 +118,14 @@ export class PbAjax extends pbMixin(LitElement) {
 
     _handleClick(ev) {
         ev.preventDefault();
-        this.trigger();
+        if (this.confirm) {
+            const dialog = this.shadowRoot.getElementById('confirmDialog');
+            dialog.confirm(this._dialogTitle, i18n(this.confirm))
+            .then(() => this.trigger())
+            .catch(() => console.log('<pb-ajax> Action cancelled'));
+        } else {
+            this.trigger();
+        }
     }
     
     trigger() {
@@ -122,8 +138,10 @@ export class PbAjax extends pbMixin(LitElement) {
     _handleResponse() {
         const resp = this.shadowRoot.getElementById('loadContent').lastResponse;
         this._message = resp;
-        const dialog = this.shadowRoot.getElementById('messageDialog');
-        dialog.open();
+        if (!this.quiet) {
+            const dialog = this.shadowRoot.getElementById('confirmDialog');
+            dialog.show(this._dialogTitle, this._message);
+        }
 
         this.emitTo('pb-end-update');
 

--- a/src/pb-browse.js
+++ b/src/pb-browse.js
@@ -1,0 +1,77 @@
+import { PbLoad } from './pb-load.js';
+
+/**
+ * Extends PbLoad to support browsing collections.
+ * 
+ * This is a reduced version of `pb-browse-docs`, which differs
+ * from a plain `pb-load` only in that it scans the returned
+ * collection listing for links to subcollections and keeps
+ * track of the current collection. 
+ *
+ * All UI elements present in `pb-browse-docs` have been removed.
+ */
+export class PbBrowse extends PbLoad {
+ 
+    static get properties() {
+        return {
+            ...super.properties,
+            /** The collection currently being browsed (if any) */
+            collection: {
+                type: String
+            },
+            /**
+             * If set, rewrite URLs to load pages as static HTML files,
+             * so no TEI Publisher instance is required
+             */
+            static: {
+                type: Boolean
+            }
+        };
+    }
+
+    constructor() {
+        super();
+        this.collection = null;
+        this.static = false;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.collection = this.getParameter('collection');
+    }
+
+    getURL(params) {
+        if (this.static) {
+            // use a static URL
+            return `collections/${this.collection ? this.collection + '/' : ''}${params.start || '1'}.html`;
+        }
+        const url = super.getURL(params);
+        return this.collection ? `${url}/${this.collection}` : url;
+    }
+
+    _onLoad(content) {
+        window.scrollTo(0, 0);
+        const div = content.querySelector('[data-root]');
+        const collection = div && div.getAttribute('data-root');
+        const writable = div && div.classList.contains('writable');
+        this.emitTo('pb-collection', {
+            writable,
+            collection
+        });
+        document.querySelectorAll('[can-write]').forEach((elem) => {
+            elem.disabled = !writable;
+        });
+        content.querySelectorAll('[data-collection]').forEach(link => {
+            link.addEventListener('click', (ev) => {
+                ev.preventDefault();
+                this.collection = link.getAttribute('data-collection');
+                this.start = 1;
+                this.setParameter('collection', this.collection);
+                this.pushHistory('browse collection');
+                console.log('<pb-browse> loading collection %s', this.collection);
+                this.emitTo('pb-search-resubmit');
+            });
+        });
+    }
+}
+customElements.define('pb-browse', PbBrowse);

--- a/src/pb-components.js
+++ b/src/pb-components.js
@@ -8,6 +8,7 @@ import './pb-link.js';
 import './pb-facs-link.js';
 import './pb-collapse.js';
 import './pb-browse-docs.js';
+import './pb-browse.js';
 import './pb-document.js';
 import './pb-load.js';
 import './pb-navigation.js';

--- a/src/pb-message.js
+++ b/src/pb-message.js
@@ -6,13 +6,7 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { translate } from "./pb-i18n.js";
 
 /**
- * Show a dialog with buttons. Used by editor.
- *
- *
- * todo:confirmation is only partly implemented needs some method to detect which button was clicked
- * @customElement
- * @polymer
- * @demo demo/pb-message.html
+ * Show a dialog with buttons. Used by ODD editor.
  */
 export class PbMessage extends LitElement {
 
@@ -58,14 +52,16 @@ export class PbMessage extends LitElement {
         super();
         this.title = '';
         this.message = '';
-        this.type = 'message'; //defaults to 'message'
+        this.type = 'message'; // defaults to 'message'
     }
 
     render() {
         return html`
         <paper-dialog id="modal">
-            <h2 id="title">${this.title}</h2>
-            <paper-dialog-scrollable id="message" class="message" tabindex="0">${unsafeHTML(this.message)}</paper-dialog-scrollable>
+            <h2 id="title">${unsafeHTML(this.title)}</h2>
+            <paper-dialog-scrollable id="message" class="message" tabindex="0">
+            ${ this.message ? unsafeHTML(this.message) : html`<slot></slot>` }
+            </paper-dialog-scrollable>
 
             <div class="buttons">
                 <paper-button dialog-confirm="dialog-confirm" autofocus="autofocus" ?hidden="${this.isConfirm()}">${translate('dialogs.close')}</paper-button>

--- a/test/pb-ajax.test.js
+++ b/test/pb-ajax.test.js
@@ -31,7 +31,7 @@ describe('recompile ODD', () => {
 
         await oneEvent(document, 'pb-end-update');
 
-        const message = ajax.shadowRoot.querySelector('paper-dialog-scrollable');
-        expect(message).to.contain.text('graves-web.xql');
+        const message = ajax.shadowRoot.querySelector('pb-message');
+        expect(message.message).to.contain('graves-web.xql');
     });
 });


### PR DESCRIPTION
The component used for browsing collections on TEI Publisher's start page, `pb-browse-docs`, has a number of problems. Most important, it includes user interface components in the shadow DOM, which are thus not customizable.

`pb-browse` is a replacement, dropping all UI components and most of the functionality. Instead it is just a thin wrapper on top of the generic `pb-load`. This makes it possible to combine the component more freely with other components and implement different types of views on a collection.