### PR TITLE
Pb facsimile fullscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lit-element": "latest",
     "lit-html": "^1.3.0",
     "marked": "^1.2.0",
-    "openseadragon": "^2.4.2",
+    "openseadragon": "github:Jinntec/openseadragon",
     "pagedjs": "^0.4.0",
     "prismjs": "^1.21.0",
     "tippy.js": "^6.2.7",

--- a/src/pb-facsimile.js
+++ b/src/pb-facsimile.js
@@ -395,4 +395,6 @@ export class PbFacsimile extends pbMixin(LitElement) {
 
 
 }
-customElements.define('pb-facsimile', PbFacsimile);
+if (!customElements.get('pb-facsimile')) {
+    customElements.define('pb-facsimile', PbFacsimile);
+}


### PR DESCRIPTION
…view

After user opened pb-facsimile in full screen popups in the text broke as their eventlisteners got lost. This fix requires a patched OSD version and the package.json will pull from the github fork.

This patch assumes that pb-facsimile will live inside of a `pb-page` element which takes the viewport. 

Can be further generified but requires more work. 