### PR TITLE
Line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .*
 !.travis.yml
+!.gitattributes
 !.editorconfig
 !.npmignore
 !.gitignore


### PR DESCRIPTION
feat(line-endings): configure git to always use LF on server and allow client-specific handling.

This just fell onto my feet trying to make a PR for pb-collapse which had CRLF line endings. To correct linter warning i used LF leaving me with a unusable diff with a lines being changed. 

To fix the issue with people using different platforms git is configured to always use LF in repo but adopt for user workspaces - see https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/

