### PR TITLE
Pb collapse right

### DIFF
--- a/demo/pb-collapse.html
+++ b/demo/pb-collapse.html
@@ -25,7 +25,6 @@
                     [slot=collapse-content] {
                         margin: 10px 20px;
                     }
-                    }
                 </style>
                 <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher" url-path="query">
                     <pb-document id="document1" path="test/osinski.xml" odd="osinski"></pb-document>

--- a/demo/pb-collapse.html
+++ b/demo/pb-collapse.html
@@ -25,6 +25,7 @@
                     [slot=collapse-content] {
                         margin: 10px 20px;
                     }
+                    }
                 </style>
                 <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher" url-path="query">
                     <pb-document id="document1" path="test/osinski.xml" odd="osinski"></pb-document>
@@ -34,8 +35,8 @@
                             <pb-param name="mode" value="metadata"/>
                         </pb-view>
                     </pb-collapse>
-                    <pb-collapse toggles>
-                        <div slot="collapse-trigger">Content</div>
+                    <pb-collapse class="icon-right" toggles>
+                        <div slot="collapse-trigger">Content with icon right</div>
                         <pb-view slot="collapse-content" src="document1" view="page"></pb-view>
                     </pb-collapse>
                 </pb-page>

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -162,28 +162,31 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
 
     static get styles() {
         return css`
-            :host {
-                display: block;
-                position:relative;
-            }
+          :host {
+            display: block;
+            position: relative;
+          }
 
-            #trigger {
-                display: table-row;
-            }
+          #trigger {
+            display: table-row;
+          }
 
-            iron-icon {
-                display: table-cell;
-                padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
-            }
-            :host(.icon-right) iron-icon{
-                position: absolute;
-                right:0;
-            }
+          iron-icon {
+            display: table-cell;
+            padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
+          }
 
-            slot[name="collapse-trigger"] {
-                display: table-cell;
-            }
+          :host(.icon-right) iron-icon {
+            position: absolute;
+            right: 0;
+          }
+
+          slot[name="collapse-trigger"] {
+            display: table-cell;
+          }
         `;
     }
 }
-customElements.define('pb-collapse', PbCollapse);
+if(!customElements.get('pb-collapse')){
+    customElements.define('pb-collapse', PbCollapse);
+}

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -10,7 +10,7 @@ import '@polymer/iron-collapse';
  * A collapsible block: in collapsed state it only shows a header and expands if clicked.
  * The header should go into slot `collapse-trigger`, the content into `collapse-content`.
  * Example:
- * 
+ *
  * ```html
  * <pb-collapse>
  *   <div slot="collapse-trigger">
@@ -164,15 +164,20 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
         return css`
             :host {
                 display: block;
+                position:relative;
             }
 
             #trigger {
                 display: table-row;
             }
 
-            #trigger iron-icon {
+            iron-icon {
                 display: table-cell;
                 padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
+            }
+            :host(.icon-right) iron-icon{
+                position: absolute;
+                right:1rem;
             }
 
             slot[name="collapse-trigger"] {

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -1,6 +1,6 @@
-import { LitElement, html, css } from 'lit-element';
-import { pbMixin } from './pb-mixin.js';
-import { themableMixin } from "./theming.js";
+import {LitElement, html, css} from 'lit-element';
+import {pbMixin} from './pb-mixin.js';
+import {themableMixin} from "./theming.js";
 import '@polymer/iron-icon';
 import '@polymer/iron-icons';
 import '@polymer/iron-collapse';
@@ -114,8 +114,8 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
     }
 
     /**
-             * opens the collapsible section
-             */
+     * opens the collapsible section
+     */
     open() {
         if (this.opened) {
             return;
@@ -148,10 +148,10 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
         return html`
             <div id="trigger" @click="${this.toggle}" class="collapse-trigger">
                 ${
-            !this.noIcons ?
+                    !this.noIcons ?
                 html`<iron-icon icon="${this.opened ? this.collapseIcon : this.expandIcon}"></iron-icon>` :
-                null
-            }
+                        null
+                }
                 <slot id="collapseTrigger" name="collapse-trigger"></slot>
             </div>
             <iron-collapse id="collapse" horizontal="${this.horizontal}" no-animation="${this.noAnimation}" .opened="${this.opened}">
@@ -162,31 +162,31 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
 
     static get styles() {
         return css`
-          :host {
-            display: block;
-            position: relative;
-          }
+            :host {
+                display: block;
+                position: relative;
+            }
 
-          #trigger {
-            display: table-row;
-          }
+            #trigger {
+                display: table-row;
+            }
 
-          iron-icon {
-            display: table-cell;
-            padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
-          }
+            iron-icon {
+                display: table-cell;
+                padding: var(--pb-collapse-icon-padding, 0 4px 0 0);
+            }
 
-          :host(.icon-right) iron-icon {
-            position: absolute;
-            right: 0;
-          }
+            :host(.icon-right) iron-icon {
+                position: absolute;
+                right: 0;
+            }
 
-          slot[name="collapse-trigger"] {
-            display: table-cell;
-          }
+            slot[name="collapse-trigger"] {
+                display: table-cell;
+            }
         `;
     }
 }
-if(!customElements.get('pb-collapse')){
+if (!customElements.get('pb-collapse')) {
     customElements.define('pb-collapse', PbCollapse);
 }

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -20,6 +20,11 @@ import '@polymer/iron-collapse';
  * </pb-collapse>
  * ```
  *
+ * By adding a CSS 'icon-right' to a `pb-collapse` the icon can be placed on the right side
+ * ```
+ * <pb-collapse class='icon-right'>
+ * ```
+ *
  * @slot collapse-trigger - trigger toggling collapsed content on/off
  * @slot collapse-content - content to be collapsed
  * @cssprop [--pb-collapse-icon-padding=0 4px 0 0] - padding in px for the "caret-down" icon left to the collapsible item

--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -177,7 +177,7 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
             }
             :host(.icon-right) iron-icon{
                 position: absolute;
-                right:1rem;
+                right:0;
             }
 
             slot[name="collapse-trigger"] {


### PR DESCRIPTION
feat(pb-collapse): icon can be positioned on the right by adding a CSS class 'icon-right'

When using e.g. in mobile menus it can be desirable to put the icon on the right side. E.g TEI-Publisher index page.

Apologies for the broken diff - couldn't find a way to commit CRLF from my machine and line-endings should be LF in the repo anyway but it is CRLF on master. If that's not acceptable we probably have to fix it on master before.

My other PR (line-endings) should fix that problem for the future. Not sure but probably can even resolve this PR when applied before.

The actual changes are just 2 CSS additions:
```
:host {
                display: block;
>>>                position: relative;
            }
```

and ```
            :host(.icon-right) iron-icon {
                position: absolute;
                right: 0;
            }
```


