### PR TITLE
fix(pb-ajax): allow users of pb-ajax to hook in

### DIFF
--- a/src/pb-ajax.js
+++ b/src/pb-ajax.js
@@ -128,11 +128,11 @@ export class PbAjax extends pbMixin(LitElement) {
         }
     }
     
-    trigger() {
+    async trigger() {
         const loader = this.shadowRoot.getElementById('loadContent');
         loader.url = `${this.getEndpoint()}/${this.url}`;
         this.emitTo('pb-start-update');
-        this.shadowRoot.getElementById('loadContent').generateRequest();
+        await this.shadowRoot.getElementById('loadContent').generateRequest();
     }
 
     _handleResponse() {


### PR DESCRIPTION
pb-ajax is performing rather long-running tasks. By awaiting the response users of pb-ajax (like pb-manage-odds) can properly handle the pb-start-update event.