### PR TITLE
fix(pb-split-list): added missing import

### DIFF
--- a/src/pb-split-list.js
+++ b/src/pb-split-list.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit-element';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { pbMixin, waitOnce } from './pb-mixin.js';
 import { themableMixin } from "./theming.js";
 import { registry } from "./urls.js";


### PR DESCRIPTION
fixed error in pb-split-list if map in category contains a label like:

```
    map {
        "category": "[A-Z]",
        "count": count($sorted),
        "label": "Alle"
    }
```

Without this patch an error `Uncaught (in promise) ReferenceError: unsafeHTML is not defined` will be thrown.
