### PR TITLE
Controlling the rendering of a disabled navigation control

### DIFF
--- a/src/pb-navigation.js
+++ b/src/pb-navigation.js
@@ -27,6 +27,16 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
              */
             keyboard: {
                 type: String
+            },
+            /**
+             * Rendition of the navigation element if it's disabled
+             * Possible values:
+             * - hidden (default if not set; control is removed from the document layout)
+             * - invisible (controll is hidden, but keeped in the document layout)
+             * - visible (control is visible)
+             */
+            rendition : {
+                type: String
             }
         };
     }
@@ -79,13 +89,20 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
 
     static get styles() {
         return css`
-            :host {
-                display: inline;
-            }
-            :host([disabled]) {
-                display: none;
-            }
-        `;
+                :host {
+                    display: inline;
+                }
+                :host([disabled]):host(:not([rendition])), :host([disabled]):host([rendition="hidden"]) {
+                    display: none;
+                }
+                :host([disabled]):host([rendition="invisible"]) {
+                    visibility: hidden;
+                }
+                :host([disabled]):host([rendition="visible"]) {
+                    visibility: visible;
+                    cursor: not-allowed;
+                }
+                `;
     }
 }
 


### PR DESCRIPTION
With new `rendition` attribute user can set is how the disabled control (button) rendered. 

In the previous and now in the default implementation, the control is removed from the document layout. 

With `rendition` attribute user can set two new options

- controll is hidden, but keeped in the document layout
- control is allways visible

These options prevent the user interface layout from changing.