### PR TITLE
Minor changes in pb-highlight concerning `scroll` property

### DIFF
--- a/src/pb-highlight.js
+++ b/src/pb-highlight.js
@@ -134,7 +134,7 @@ export class PbHighlight extends pbMixin(LitElement) {
         if (ev.detail.source != this && ev.detail.id === this.key) {
             this._className = 'highlight-on';
             if (ev.detail.scroll) {
-                this.scrollIntoView({ behaviour: 'smooth' });
+                this.scrollIntoView({ block: "center", behaviour: 'smooth' });
             }
             if (this.duration > 0) {
                 setTimeout(function () {

--- a/src/pb-highlight.js
+++ b/src/pb-highlight.js
@@ -133,7 +133,7 @@ export class PbHighlight extends pbMixin(LitElement) {
     _highlightOn(ev) {
         if (ev.detail.source != this && ev.detail.id === this.key) {
             this._className = 'highlight-on';
-            if (ev.detail.scroll) {
+            if (ev.detail.scroll && this.disabled == false) {
                 this.scrollIntoView({ block: "center", behaviour: 'smooth' });
             }
             if (this.duration > 0) {


### PR DESCRIPTION
- Changes default vertical alignment of property `scroll` (center instead of top). This way the user can read the preceding context.
- When `<pb-highlight>` was disabled, the element was still scrolled into view: this has been fixed.