### PR TITLE
feat(pb-facsimile): added option to add download icon to trigger down…

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -40,7 +40,8 @@
   },
   "pb-facsimile": {
     "demo/pb-facsimile.html": "Demo",
-    "demo/pb-facsimile-2.html": "Align text page with facsimile"
+    "demo/pb-facsimile-2.html": "Align text page with facsimile",
+    "demo/pb-facsimile-3.html": "With Download Button"
   },
   "pb-image-strip": {
     "demo/pb-image-strip-view.html": "Demo with pb-view",

--- a/demo/pb-facsimile-3.html
+++ b/demo/pb-facsimile-3.html
@@ -1,0 +1,82 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+
+    <title>pb-view Demo</title>
+    <!--scripts-->
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" defer></script>
+    <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
+    <script type="module" src="../node_modules/@polymer/iron-icons/iron-icons.js"></script>
+    <script type="module" src="../node_modules/@polymer/paper-fab/paper-fab.js"></script>
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-document.js"></script>
+    <script type="module" src="../src/pb-view.js"></script>
+    <script type="module" src="../src/pb-navigation.js"></script>
+    <script type="module" src="../src/pb-facsimile.js"></script>
+    <script type="module" src="../src/pb-facs-link.js"></script>
+    <!--/scripts-->
+</head>
+
+<body>
+    <pb-demo-snippet>
+        <template>
+            <style type="text/css">
+            body {
+                --paper-fab-background: #35424b;
+            }
+
+            main {
+                position: relative;
+                height: 70vh;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-start;
+            }
+
+            pb-navigation {
+                position: absolute;
+                bottom: 45%;
+                --paper-fab-background: #35424b;
+                color: white;
+            }
+
+            pb-navigation[direction=backward] {
+                left: 20px;
+            }
+
+            pb-navigation[direction=forward] {
+                right: 20px;
+            }
+
+            pb-facsimile {
+                flex: 1 1;
+                max-width: 50vw;
+                margin-right: 20px;
+            }
+            </style>
+            <pb-page endpoint="http://localhost:8080/exist/apps/tei-publisher" url-path="query">
+                <pb-document id="document1" path="test/cortes_to_dantiscus.xml" odd="dantiscus"></pb-document>
+                <main>
+                    <pb-facsimile base-uri="https://apps.existsolutions.com/cantaloupe/iiif/2/" default-zoom-level="0"
+                        show-navigator show-navigation-control show-home-control show-download-control subscribe="transcription">
+                    </pb-facsimile>
+
+                    <!-- Navigate to previous page -->
+                    <pb-navigation direction="backward" keyboard="left">
+                        <paper-fab icon="icons:chevron-left"></paper-fab>
+                    </pb-navigation>
+                    <pb-view id="view1" src="document1" view="page" xpath="//text[@type='source']" append-footnotes>
+                    </pb-view>
+                    <!-- Navigate to next page -->
+                    <pb-navigation direction="forward" keyboard="right">
+                        <paper-fab icon="icons:chevron-right"></paper-fab>
+                    </pb-navigation>
+                </main>
+            </pb-page>
+        </template>
+    </pb-demo-snippet>
+</body>
+
+</html>


### PR DESCRIPTION
…load of current viewport. Added a demo for the feature

Example:
```
<pb-facsimile show-download-control="show-download-control">
```

will display a download icon in the bottom left of the element. Couldn't figure out how to add an icon to the builtin toolbar which would have been more preferrable but does the job for the project here.

To make it work the crossOriginPolicy property of the Viewer needed to be set. It defaults to 'anonymous' and was tested with Zuericher. An additional `cors` attribute allows to overwrite the default with 'use-credentials' if necessary.

