### PR TITLE
change of width in pb-collapase icons

### DIFF
--- a/src/pb-collapse.js
+++ b/src/pb-collapse.js
@@ -173,8 +173,9 @@ export class PbCollapse extends themableMixin(pbMixin(LitElement)) {
             }
 
             #trigger {
-                display: flex;
-                align-items:center
+                display: grid;
+                align-items:center;
+                grid-template-columns:auto auto;
             }
 
             iron-icon {


### PR DESCRIPTION
The use of `display:flex` in the `<pb-collapse>` `#trigger` was causing readjustments of the size of the icons. See:

![image](https://github.com/user-attachments/assets/2a85bb3c-42c2-401d-bae7-95e8d819e885)

This PR proposes using `grid` instead of `flex` to avoid these changes.