### PR TITLE
Allow placing the annotation element after the selected text

### DIFF
--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -633,8 +633,8 @@ class PbViewAnnotate extends PbView {
     const endRange = rangeToPoint(range.endContainer, range.endOffset, 'end');
     const adjustedRange = {
       context: startRange.parent,
-      start: startRange.offset,
-      end: info.before ? startRange.offset : endRange.offset,
+      start: (info.position === 'after') ? endRange.offset : startRange.offset,
+      end: (info === undefined || info.position === 'before') ? startRange.offset : endRange.offset,
       text: info.before ? '' : range.cloneContents().textContent,
       before: info.before
     };


### PR DESCRIPTION
In the annotation view, inserted `<pb>` and `<note>` elements are placed before the selected text.

The proposed change, combined with changes on the TEI Publisher side, allows the user to choose where the inserted element will be placed by specifying 'after' or 'before' value in the  `@class` attribute of the button for the annotation element.

See parallel required [pull request](https://github.com/eeditiones/tei-publisher-app/pull/232) in the TEI Publisher.
