### PR TITLE
fix(pb-timeline): Fix the timeframe label for some edge cases

### DIFF
--- a/src/pb-timeline.js
+++ b/src/pb-timeline.js
@@ -442,7 +442,7 @@ export class PbTimeline extends pbMixin(LitElement) {
     if (this.dataObj.data.length === 1) {
       return this.dataObj.data[0].category;
     }
-    return `${this.dataObj.data[0].category} – ${this.dataObj.data[this.dataObj.data.length - 1].category}`;
+    return `${this.dataObj.data[0].selectionStart} – ${this.dataObj.data[this.dataObj.data.length - 1].selectionEnd}`;
   }
 
   getSelectedStartDateStr() {


### PR DESCRIPTION
Like the last item being in the end of the 'bucket' of the timeline