### PR TITLE
feat(pb-pb-view-annotate): added optional attribute 'popup'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@babel/runtime": "7.11.2",
     "@cwmr/paper-autocomplete": "^4.0.0",
-    "@jinntec/jinn-codemirror": "^1.13.5",
+    "@jinntec/jinn-codemirror": "^1.17.5",
     "@lrnwebcomponents/es-global-bridge": "^7.0.4",
     "@polymer/app-layout": "^3.1.0",
     "@polymer/iron-ajax": "^3.0.1",

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -250,6 +250,9 @@ class PbViewAnnotate extends PbView {
       caseSensitive: {
         type: Boolean
       },
+      showPopup:{
+          type:Boolean
+      },
       ...super.properties,
     };
   }
@@ -268,6 +271,7 @@ class PbViewAnnotate extends PbView {
   connectedCallback() {
     super.connectedCallback();
 
+    this.showPopup = this.getAttribute('popup') !== 'false';
     let isMouseDown = false;
 
     this._inHandler = false;
@@ -910,7 +914,16 @@ class PbViewAnnotate extends PbView {
       }
     }
 
-    this._createTooltip(span);
+    if(this.popup){
+        this._createTooltip(span);
+    }else{
+        span.addEventListener('click', (ev) =>{
+            const data = JSON.parse(span.dataset.annotation);
+            const text = span.textContent;
+            this.emitTo('pb-annotation-edit', Object.assign({}, { target: span, type: span.dataset.type, properties: data, text }));
+        });
+    }
+
   }
 
   _clearMarkers() {

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -502,6 +502,9 @@ class PbViewAnnotate extends PbView {
       throw new Error('An error occurred. The annotation may not be displayed. You should consider saving and reloading the document.');
     }
     this._rangesMap.set(span, teiRange);
+      const data = JSON.parse(span.dataset.annotation);
+      const text = span.textContent;
+      this.emitTo('pb-annotation-edit', Object.assign({}, { target: span, type: span.dataset.type, properties: data, text }));
 
     if (!batch) {
       this.refreshMarkers();
@@ -917,9 +920,9 @@ class PbViewAnnotate extends PbView {
     if(this.showPopup){
         this._createTooltip(span);
     }else{
+        const data = JSON.parse(span.dataset.annotation);
+        const text = span.textContent;
         span.addEventListener('click', (ev) =>{
-            const data = JSON.parse(span.dataset.annotation);
-            const text = span.textContent;
             this.emitTo('pb-annotation-edit', Object.assign({}, { target: span, type: span.dataset.type, properties: data, text }));
         });
     }

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -914,7 +914,7 @@ class PbViewAnnotate extends PbView {
       }
     }
 
-    if(this.popup){
+    if(this.showPopup){
         this._createTooltip(span);
     }else{
         span.addEventListener('click', (ev) =>{


### PR DESCRIPTION
By setting `popup` to `false` the usual tippy popup can be suppressed. In that case only the event annotation-edit event is dispatched and a listener may decide where to put the content.