### PR TITLE
fix(pb-combo-box): Clear items before refetching (fixes #189)

### DIFF
--- a/src/pb-combo-box.js
+++ b/src/pb-combo-box.js
@@ -63,9 +63,11 @@ export class PbComboBox extends pbMixin(LitElement) {
             },
             /**
              * Preload all items from the remote data source at startup
+             * Must be of type string because tom-select supports setting
+             * that property to "focus" (load data on focus)
              */
             preload: {
-                type: Boolean
+                type: String
             },
             /**
              * Name of the event to be emitted when the user leaves the form control
@@ -160,6 +162,12 @@ export class PbComboBox extends pbMixin(LitElement) {
                 options.searchField = [];
                 options.preload = this.preload;
                 options.load = (query, callback) => {
+                    if (this._select) {
+                      // The default behaviour of tom-select is to keep existing items when loading
+                      // again from the source. We want to show only items the server provides, so
+                      // we need to clear "stale" items before fetching.
+                      this._select.clearOptions();
+                    }
                     fetch(`${url}?query=${encodeURIComponent(query)}`, {
                         method: 'GET',
                         mode: 'cors',


### PR DESCRIPTION
This PR addresses an issue where `tom-select` appends new items fetched from the server to the existing list, instead of replacing them (see https://github.com/eeditiones/tei-publisher-components/issues/189). While this behavior makes sense when using tom-select's client-side search functionality, the primary use case for `pb-combo-box` is probably to have the server determine which items to display. To align with this use case, the items should be cleared before refetching new data from the server.

Additionally, I changed the type of the `preload` property from `Boolean` to `String`. `tom-select` supports setting that property to the string `focus`, which triggers loading data when the control is focused. This change allows `pb-combo-box` to display items even if no search term has been entered.