### PR TITLE
fix(pb-formula): replace XML entities

### DIFF
--- a/src/pb-formula.js
+++ b/src/pb-formula.js
@@ -68,7 +68,7 @@ function _initMath(context, formulas) {
                 source = formula.innerHTML.replaceAll(/&\w+;/g, function (m) {
                     return {
                         '&amp;': '&',
-                        '&lt' : '<'
+                        '&lt;' : '<'
                     }[m];
                 });
                 chtml = window.MathJax.tex2chtml(source, options);

--- a/src/pb-formula.js
+++ b/src/pb-formula.js
@@ -65,7 +65,12 @@ function _initMath(context, formulas) {
                 chtml = window.MathJax.mathml2chtml(source, options);
             } else {
                 window.MathJax.texReset();
-                source = formula.innerHTML;
+                source = formula.innerHTML.replaceAll(/&\w+;/g, function (m) {
+                    return {
+                        '&amp;': '&',
+                        '&lt' : '<'
+                    }[m];
+                });
                 chtml = window.MathJax.tex2chtml(source, options);
             }
             formula.innerHTML = '';


### PR DESCRIPTION
LaTex code within the `<tei:formula>` element presents the XML entities which need to be replaced before typesetting the formula.

E.g. of current display:

```
<formula> \begin{array}{c@{\hspace{1em}}c} 1 &amp; 2 \\ 3 &amp; 4 \end{array} </formula>
```
![imaxe](https://github.com/user-attachments/assets/2d104188-ed52-4244-a9ee-054d56b416ee)
