### PR TITLE
feat(pb-view-annotate): introduce 'popup' attribute to suppress popup…

### DIFF
--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -498,6 +498,10 @@ class PbViewAnnotate extends PbView {
       throw new Error('An error occurred. The annotation may not be displayed. You should consider saving and reloading the document.');
     }
     this._rangesMap.set(span, teiRange);
+    // pass annotation to event for processing by foreign component
+    const data = JSON.parse(span.dataset.annotation);
+    const text = span.textContent;
+    this.emitTo('pb-annotation-edit', Object.assign({}, { target: span, type: span.dataset.type, properties: data, text }));
 
     if (!batch) {
       this.refreshMarkers();
@@ -910,7 +914,16 @@ class PbViewAnnotate extends PbView {
       }
     }
 
+    if(this.showPopup){
     this._createTooltip(span);
+    }else{
+        const data = JSON.parse(span.dataset.annotation);
+        const text = span.textContent;
+        span.addEventListener('click', (ev) =>{
+            this.emitTo('pb-annotation-edit', Object.assign({}, { target: span, type: span.dataset.type, properties: data, text }));
+        });
+    }
+
   }
 
   _clearMarkers() {


### PR DESCRIPTION
… but dispatch a pb-annotation-edit event passing on the anotation details

This extension allows an external component to initiate editing of an annotation without a popup.

This reduces the number of clicks if another component already shows editor and actions right after a selection has been made.

Change only comes into effect if component is explicitly configured like this:
```
<pb-view-annotation popup="false">
```
otherwise existing behavior is preserved.



