### PR TITLE
fix(pb-facsimile): perform better with many pb-facs-links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -2424,7 +2425,6 @@
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-scope": "5.1.1"
       }
@@ -2478,6 +2478,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -4261,7 +4262,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -4271,7 +4271,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -4281,7 +4280,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
       "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -4293,7 +4291,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -4302,8 +4299,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -5186,6 +5182,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5882,6 +5879,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -6135,6 +6133,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -7927,6 +7926,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8072,6 +8072,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -8195,7 +8196,6 @@
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -10808,8 +10808,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/karma": {
       "version": "6.4.4",
@@ -10817,6 +10816,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -11318,7 +11318,8 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "node_modules/leaflet-control-geocoder": {
       "version": "2.4.0",
@@ -11652,8 +11653,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -11930,6 +11930,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
       "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "peer": true,
       "bin": {
         "marked": "bin/marked"
       },
@@ -12276,6 +12277,7 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
       "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -12611,7 +12613,6 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
       "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -12625,7 +12626,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -12634,15 +12634,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/nise/node_modules/path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -17397,6 +17395,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17666,6 +17665,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
       "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
         "@semantic-release/error": "^2.2.0",
@@ -17957,7 +17957,6 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
       "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^10.3.0",
@@ -17986,7 +17985,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -17996,7 +17994,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18006,7 +18003,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -20548,6 +20544,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -22186,7 +22183,6 @@
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "eslint-scope": "5.1.1"
       }
@@ -22231,6 +22227,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -23809,7 +23806,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -23819,7 +23815,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -23829,7 +23824,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
       "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -23841,7 +23835,6 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
           "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "type-detect": "4.0.8"
           }
@@ -23852,8 +23845,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -24707,7 +24699,8 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -25240,6 +25233,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
       "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001503",
         "electron-to-chromium": "^1.4.431",
@@ -25424,6 +25418,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -26848,6 +26843,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -27087,6 +27083,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -27191,8 +27188,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "eslint-rule-extender": {
       "version": "0.0.1",
@@ -28993,14 +28989,14 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "karma": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -29419,7 +29415,8 @@
     "leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "leaflet-control-geocoder": {
       "version": "2.4.0",
@@ -29675,8 +29672,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -29905,7 +29901,8 @@
     "marked": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw=="
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "peer": true
     },
     "marked-terminal": {
       "version": "4.2.0",
@@ -30157,6 +30154,7 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
       "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -30428,7 +30426,6 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
       "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -30442,7 +30439,6 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
           "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "type-detect": "4.0.8"
           }
@@ -30451,15 +30447,13 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -33987,6 +33981,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -34193,6 +34188,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
       "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
         "@semantic-release/error": "^2.2.0",
@@ -34412,7 +34408,6 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
       "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^10.3.0",
@@ -34426,22 +34421,19 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/test/pb-facsimile.test.js
+++ b/test/pb-facsimile.test.js
@@ -1,8 +1,10 @@
-import { expect, fixture, oneEvent } from '@open-wc/testing';
+import { expect, fixture, oneEvent, waitUntil } from '@open-wc/testing';
 import { cleanup, waitForPage } from './util';
+import sinon from 'sinon';
 
 import '../src/pb-page.js';
 import '../src/pb-facsimile.js';
+import '../src/pb-facs-link.js';
 
 describe('pb-facsimile', () => {
   afterEach(cleanup);
@@ -50,5 +52,225 @@ describe('pb-facsimile', () => {
 
     const otherChild = el.querySelector('#other');
     expect(otherChild, 'Other elements should not have been removed from the DOM').to.exist;
+  });
+});
+
+describe.only('request handling', () => {
+  /**
+   * @type {import('sinon').SinonFakeXMLHttpRequestStatic}
+   */
+  let xhr;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+  });
+  afterEach(() => {
+    xhr.restore();
+    cleanup();
+  });
+
+  it('Deduplicates network requests for the same URL if all pb-facs-links point to the same', async () => {
+    /**
+     * @type {import('sinon').SinonFakeXMLHttpRequest[]}
+     */
+    const requests = [];
+    xhr.onCreate = request => {
+      requests.push(request);
+
+      setTimeout(() => {
+        request.respond(
+          200,
+          { 'content-Type': 'application/json' },
+          JSON.stringify({
+            '@context': 'http://iiif.io/api/image/2/context.json',
+            '@id': 'https://apps.existsolutions.com/cantaloupe/iiif/2/12446_000_BCz_1596p302.jpg',
+            protocol: 'http://iiif.io/api/image',
+            width: 2480,
+            height: 3507,
+            sizes: [
+              { width: 78, height: 110 },
+              { width: 155, height: 219 },
+              { width: 310, height: 438 },
+              { width: 620, height: 877 },
+              { width: 1240, height: 1754 },
+              { width: 2480, height: 3507 },
+            ],
+            tiles: [{ width: 512, height: 512, scaleFactors: [1, 2, 4, 8, 16, 32] }],
+            profile: [
+              'http://iiif.io/api/image/2/level2.json',
+              {
+                formats: ['jpg', 'tif', 'gif', 'png'],
+                maxArea: 8697360,
+                qualities: ['bitonal', 'default', 'gray', 'color'],
+                supports: [
+                  'regionByPx',
+                  'sizeByW',
+                  'sizeByWhListed',
+                  'cors',
+                  'regionSquare',
+                  'sizeByDistortedWh',
+                  'canonicalLinkHeader',
+                  'sizeByConfinedWh',
+                  'sizeByPct',
+                  'jsonldMediaType',
+                  'regionByPct',
+                  'rotationArbitrary',
+                  'sizeByH',
+                  'baseUriRedirect',
+                  'rotationBy90s',
+                  'profileLinkHeader',
+                  'sizeByForcedWh',
+                  'sizeByWh',
+                  'mirroring',
+                ],
+              },
+            ],
+          }),
+        );
+      });
+    };
+    const el = await fixture(`
+      <div>
+        <pb-facsimile
+          base-uri="https://apps.existsolutions.com/cantaloupe/iiif/2/"
+          subscribe="transcription"
+        >
+          <h3 slot="before">Facsimile Viewer Test</h3>
+          <div slot="after">Status: <span id="status"></span></div>
+        </pb-facsimile>
+        <h3 id="other">Some other data</h3>
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p302.jpg"
+          coordinates="[ 1,2,3,4 ]"
+          >First area</pb-facs-link
+        >
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p302.jpg"
+          coordinates="[ 5,6,7,8 ]"
+          >Second area</pb-facs-link
+        >
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p302.jpg"
+          coordinates="[ 9,10,11,12 ]"
+          >Third area</pb-facs-link
+        >
+      </div>
+    `);
+
+    const facsimile = el.querySelector('pb-facsimile');
+
+    await oneEvent(facsimile, 'pb-facsimile-status');
+
+    expect(requests.length).to.equal(1, 'there should have been exactly one request here');
+    expect(requests[0].url).to.equal(
+      'https://apps.existsolutions.com/cantaloupe/iiif/2/12446_000_BCz_1596p302.jpg/info.json',
+    );
+  });
+
+  it('Deduplicates network requests for the same URL if the pb-facs-links point to the a small set of different ones', async () => {
+    /**
+     * @type {import('sinon').SinonFakeXMLHttpRequest[]}
+     */
+    const requests = [];
+    xhr.onCreate = request => {
+      requests.push(request);
+
+      setTimeout(() => {
+        request.respond(
+          200,
+          { 'content-Type': 'application/json' },
+          JSON.stringify({
+            '@context': 'http://iiif.io/api/image/2/context.json',
+            '@id': 'https://apps.existsolutions.com/cantaloupe/iiif/2/12446_000_BCz_1596p302.jpg',
+            protocol: 'http://iiif.io/api/image',
+            width: 2480,
+            height: 3507,
+            sizes: [
+              { width: 78, height: 110 },
+              { width: 155, height: 219 },
+              { width: 310, height: 438 },
+              { width: 620, height: 877 },
+              { width: 1240, height: 1754 },
+              { width: 2480, height: 3507 },
+            ],
+            tiles: [{ width: 512, height: 512, scaleFactors: [1, 2, 4, 8, 16, 32] }],
+            profile: [
+              'http://iiif.io/api/image/2/level2.json',
+              {
+                formats: ['jpg', 'tif', 'gif', 'png'],
+                maxArea: 8697360,
+                qualities: ['bitonal', 'default', 'gray', 'color'],
+                supports: [
+                  'regionByPx',
+                  'sizeByW',
+                  'sizeByWhListed',
+                  'cors',
+                  'regionSquare',
+                  'sizeByDistortedWh',
+                  'canonicalLinkHeader',
+                  'sizeByConfinedWh',
+                  'sizeByPct',
+                  'jsonldMediaType',
+                  'regionByPct',
+                  'rotationArbitrary',
+                  'sizeByH',
+                  'baseUriRedirect',
+                  'rotationBy90s',
+                  'profileLinkHeader',
+                  'sizeByForcedWh',
+                  'sizeByWh',
+                  'mirroring',
+                ],
+              },
+            ],
+          }),
+        );
+      });
+    };
+    const el = await fixture(`
+      <div>
+        <pb-facsimile
+          base-uri="https://apps.existsolutions.com/cantaloupe/iiif/2/"
+          subscribe="transcription"
+        >
+          <h3 slot="before">Facsimile Viewer Test</h3>
+          <div slot="after">Status: <span id="status"></span></div>
+        </pb-facsimile>
+        <h3 id="other">Some other data</h3>
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p302.jpg"
+          coordinates="[ 1,2,3,4 ]"
+          >First area</pb-facs-link
+        >
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p303.jpg"
+          coordinates="[ 5,6,7,8 ]"
+          >Second area</pb-facs-link
+        >
+        <pb-facs-link
+          emit="transcription"
+          facs="12446_000_BCz_1596p302.jpg"
+          coordinates="[ 9,10,11,12 ]"
+          >Third area</pb-facs-link
+        >
+      </div>
+    `);
+
+    const facsimile = el.querySelector('pb-facsimile');
+
+    await oneEvent(facsimile, 'pb-facsimile-status');
+
+    expect(requests.length).to.equal(2, 'there should have been exactly one request here');
+    expect(requests[0].url).to.equal(
+      'https://apps.existsolutions.com/cantaloupe/iiif/2/12446_000_BCz_1596p303.jpg/info.json',
+    );
+    expect(requests[1].url).to.equal(
+      'https://apps.existsolutions.com/cantaloupe/iiif/2/12446_000_BCz_1596p302.jpg/info.json',
+    );
   });
 });


### PR DESCRIPTION
If there are many (like 400) pb-facs-links, the old implementation happily sent something in the order of 400*400 = 160.000 facsimiles to OSD. For every pb-facs-link that appears in the DOM all facsimiles are 'opened' in OSD. Which in turn passed all those requests to the endpoint serving manifests.

Debounce these to only do 400 requests: when all of the pb-facs-link elements are 'in'. Furthermore,
if they are all the same, send only one: the unique one.