### PR TITLE
fix(pb-navigation): do not navigate when we have anything focused

### DIFF
--- a/src/pb-hotkeys.js
+++ b/src/pb-hotkeys.js
@@ -7,8 +7,14 @@ const excluded = new Set(EXCLUDED_TAGS);
 let firstLoad = true;
 if (firstLoad) {
   hotkeys.filter = event => {
-    const { tagName } = event.target || event.srcElement;
-    return !(tagName.isContentEditable || excluded.has(tagName));
+    const { target } = /** @type {{target: HTMLElement}} */ (event);
+    if (target.isContentEditable) {
+      return false;
+    }
+
+    const { tagName } = target;
+
+    return !excluded.has(tagName);
   };
   firstLoad = false;
 }

--- a/src/pb-navigation.js
+++ b/src/pb-navigation.js
@@ -57,7 +57,14 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
 
     this.subscribeTo('pb-update', this._update.bind(this));
 
-    this.registerHotkey('next', () => this.emitTo('pb-navigate', { direction: this.direction }));
+    this.registerHotkey('next', () => {
+      // Do not handle this hotkey if we have something focused. Otherwise we would basically
+      // disable the arrowkeys in input fields
+      if (window.document.activeElement && window.document.activeElement !== window.document.body) {
+        return;
+      }
+      this.emitTo('pb-navigate', { direction: this.direction });
+    });
 
     this.signalReady();
   }


### PR DESCRIPTION
Like any web component. Some other hotkeys might be valid when we have some webcomponent focused. But navigation not. Navigation should only be done when nothing is focused.

Also fix some code in pb-hotkeys that tried to read `isContentEditable` from a `string`