### PR TITLE
Pass accept: text/css header to theme resource

### DIFF
--- a/src/theming.js
+++ b/src/theming.js
@@ -32,7 +32,7 @@ export async function loadStylesheets(urls) {
 }
 
 function loadResource(url) {
-  return fetch(url)
+  return fetch(url, { headers: { accept: 'text/css' } })
     .then(response => {
       if (response.ok) {
         return response.text();


### PR DESCRIPTION
So build systems like vite will respond correctly.

Vite uses the accept header to predict how a file will be used. Passing nothing (like we did here) makes it respond with javascript. Telling it to respond with CSS makes a build system like vite work better.