### PR TITLE
Improve pb-paginate component

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -89,6 +89,9 @@
   "pb-message": {
     "demo/pb-message.html": "Demo"
   },
+  "pb-paginate": {
+    "demo/pb-paginate.html": "Demo"
+  },
   "pb-popover": {
     "demo/pb-popover.html": "Demo"
   },

--- a/demo/pb-browse-docs.html
+++ b/demo/pb-browse-docs.html
@@ -8,8 +8,8 @@
     <title>pb-browse-docs Demo</title>
     <link rel="stylesheet" href="demo.css">
     <!--scripts-->
-    
-    
+
+
     <script type="module" src="../src/docs/pb-demo-snippet.js"></script>
     <script type="module" src="../src/pb-page.js"></script>
     <script type="module" src="../src/pb-lang.js"></script>
@@ -73,7 +73,7 @@
                         display: none;
                     }
                 }
-                
+
                 .toolbar {
                     display: flex;
                     justify-content: space-between;
@@ -82,7 +82,7 @@
                     border-bottom: 1px solid #a0a0a0;
                 }
             </style>
-            <pb-page endpoint="." 
+            <pb-page endpoint="."
                 url-doc="path|query" url-skip="lang," url-id="query|hash">
                 <div class="toolbar">
                     <pb-login id="login" group="tei"></pb-login>

--- a/demo/pb-paginate.html
+++ b/demo/pb-paginate.html
@@ -1,0 +1,46 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"
+    />
+    <title>pb-paginate</title>
+    <!-- Minimal scripts for local dev demos -->
+    <script type="module" src="../src/pb-page.js"></script>
+    <script type="module" src="../src/pb-paginate.js"></script>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <pb-page endpoint=".">
+      <section>
+        <h2>Some results, page 5</h2>
+        <pb-paginate start="25" total="1234" perPage="5"></pb-paginate>
+      </section>
+
+      <section>
+        <h2>At the end</h2>
+        <pb-paginate start="1230" total="1234" perPage="5"></pb-paginate>
+      </section>
+
+      <section>
+        <h2>Many results</h2>
+        <pb-paginate start="90000" total="1000000" perPage="5"></pb-paginate>
+      </section>
+
+      <section>
+        <h2>Few results</h2>
+        <pb-paginate start="5" total="6" perPage="5"></pb-paginate>
+      </section>
+
+      <section>
+        <h2>At the start</h2>
+        <pb-paginate start="5" total="60" perPage="5"></pb-paginate>
+      </section>
+    </pb-page>
+  </body>
+</html>

--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -1,5 +1,12 @@
 {
-  "language": "Language",
+	"language": "Language",
+	"paginate": {
+		"pagination": "Pagination",
+		"next": "Next",
+		"previous": "Previous",
+		"page": "Page {{nr}}",
+		"ellipsislabel": "ellipsis indicating non-visible pages"
+	},
   "menu": {
     "documentation": "Documentation",
     "admin": {

--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -62,6 +62,7 @@
     "filterPlaceholder": "Filter",
     "items": "Found {{count}} item",
     "items_plural": "Found {{count}} items",
+    "items_other": "Found {{count}} items",
     "title": "Title",
     "author": "Author",
     "modificationDate": "Modification Date",

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,7 +249,6 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -322,7 +321,6 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -1486,7 +1484,6 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1714,6 +1711,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3756,6 +3754,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4220,6 +4219,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4827,8 +4827,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/core-js": {
       "version": "2.6.12",
@@ -5356,6 +5355,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -5741,6 +5741,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6623,7 +6624,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7699,7 +7699,6 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -7780,7 +7779,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet-control-geocoder": {
       "version": "3.3.1",
@@ -10823,6 +10823,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12062,6 +12063,7 @@
       "integrity": "sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12238,6 +12240,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12551,6 +12554,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -13817,6 +13821,7 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13925,6 +13930,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -14507,7 +14513,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -14553,7 +14558,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -15280,7 +15284,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -15470,6 +15473,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -16721,7 +16725,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -17020,6 +17025,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -17420,8 +17426,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "core-js": {
       "version": "2.6.12",
@@ -17799,6 +17804,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -18043,6 +18049,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -18613,8 +18620,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -19311,8 +19317,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "jsonfile": {
       "version": "6.2.0",
@@ -19369,7 +19374,8 @@
     "leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "leaflet-control-geocoder": {
       "version": "3.3.1",
@@ -21354,7 +21360,8 @@
             "picomatch": {
               "version": "4.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "peer": true
             }
           }
         },
@@ -22177,6 +22184,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.2.tgz",
       "integrity": "sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.55.2",
         "@rollup/rollup-android-arm64": "4.55.2",
@@ -22295,6 +22303,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -22488,7 +22497,8 @@
           "version": "15.0.12",
           "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
           "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "marked-terminal": {
           "version": "7.3.0",
@@ -23322,7 +23332,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "devOptional": true
+      "devOptional": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.19.3",
@@ -23386,6 +23397,7 @@
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
         "@unrs/resolver-binding-android-arm64": "1.11.1",

--- a/src/pb-mixin.js
+++ b/src/pb-mixin.js
@@ -102,9 +102,16 @@ export function getSubscribedChannels(elem) {
  * channels, other components can address only one of the two.
  *
  * @mixinFunction
+ *
+ * @template {typeof import('lit-element').LitElement} T
+ * @param {T} BaseClass
+ *
  */
-export const pbMixin = superclass =>
-  class PbMixin extends superclass {
+export const pbMixin = BaseClass =>
+  /**
+   * @augments {BaseClass}
+   */
+  class PbMixin extends BaseClass {
     static get properties() {
       return {
         /**

--- a/src/pb-paginate.js
+++ b/src/pb-paginate.js
@@ -243,15 +243,15 @@ export class PbPaginate extends themableMixin(pbMixin(LitElement)) {
    */
   _handleClick(item) {
     this.start = (item - 1) * this.perPage + 1;
-    ['pb-load', 'pb-paginate'].forEach(ev => {
-      this.emitTo(ev, {
+    for (const eventName of ['pb-load', 'pb-paginate']) {
+      this.emitTo(eventName, {
         params: {
           start: this.start,
           'per-page': this.perPage,
           page: item,
         },
       });
-    });
+    }
   }
 
   /**
@@ -259,15 +259,15 @@ export class PbPaginate extends themableMixin(pbMixin(LitElement)) {
    */
   _handleFirst() {
     this.start = 1;
-    ['pb-load', 'pb-paginate'].forEach(event => {
-      this.emitTo(event, {
+    for (const eventName of ['pb-load', 'pb-paginate']) {
+      this.emitTo(eventName, {
         params: {
           start: 1,
           'per-page': this.perPage,
           page: 0,
         },
       });
-    });
+    }
   }
 
   /**
@@ -275,15 +275,15 @@ export class PbPaginate extends themableMixin(pbMixin(LitElement)) {
    */
   _handleLast() {
     this.start = (this.pageCount - 1) * this.perPage + 1;
-    ['pb-load', 'pb-paginate'].forEach(event => {
-      this.emitTo(event, {
+    for (const eventName of ['pb-load', 'pb-paginate']) {
+      this.emitTo(eventName, {
         params: {
           start: this.start,
           'per-page': this.perPage,
           page: this.pageCount - 1,
         },
       });
-    });
+    }
   }
 
   static get styles() {

--- a/src/pb-paginate.js
+++ b/src/pb-paginate.js
@@ -1,7 +1,20 @@
-import { LitElement, html, css, nothing } from 'lit';
-import { pbMixin } from './pb-mixin.js';
-import { translate } from './pb-i18n.js';
+import { LitElement, css, html, nothing } from 'lit';
 import './pb-icon.js';
+import { translate } from './pb-i18n.js';
+import { themableMixin } from './theming.js';
+import { pbMixin } from './pb-mixin.js';
+
+/**
+ * @typedef {{type: 'overflow'}} Overflow
+ */
+
+/**
+ * @typedef {{type: 'page', label: number, class: 'active'|''}} Page
+ */
+
+/**
+ * @typedef {Overflow | Page} PageOrOverflow
+ */
 
 /**
  * Display a pagination control from which the user can select a page to view
@@ -15,7 +28,7 @@ import './pb-icon.js';
  * @fires pb-results-received - When received, recalculates page ranges to display according to the parameters received
  * @csspart count - the span displaying the number of items
  */
-export class PbPaginate extends pbMixin(LitElement) {
+export class PbPaginate extends themableMixin(pbMixin(LitElement)) {
   static get properties() {
     return {
       ...super.properties,
@@ -69,74 +82,208 @@ export class PbPaginate extends pbMixin(LitElement) {
         type: Number,
       },
       /**
-       * todo:
+       * The actual pages
        */
       pages: {
         type: Array,
       },
+
       /**
        * show or hide (i.e. generate) previous and next buttons,
-       * default value is false, controls are not generated
+       * default value is true, controls are generated
        */
       showPreviousNext: {
         type: Boolean,
-        attribute: 'show-previous-next'
-      }
+        attribute: 'show-previous-next',
+      },
     };
   }
 
   constructor() {
     super();
+    /**
+     * The total amount of results
+     * @type {number}
+     */
     this.total = 0;
+
+    /**
+     * The start of this page. 1-based
+     * @type {number}
+     */
     this.start = 1;
+
+    /**
+     * How many items per page
+     * @type {number}
+     */
     this.perPage = 10;
+
+    /**
+     * The current page
+     * @type {number}
+     */
     this.page = 1;
+
+    /**
+     * The total amount of pages
+     * @type {number}
+     */
     this.pageCount = 10;
+
+    /**
+     * The amount of pages to show
+     * @type {number}
+     */
     this.range = 5;
+
+    /**
+     * The actual pages
+     * @type {PageOrOverflow[]}
+     */
     this.pages = [];
     this.foundLabel = 'browse.items';
+
+    this.showPreviousNext = true;
   }
 
   connectedCallback() {
     super.connectedCallback();
+
     this.subscribeTo('pb-results-received', this._refresh.bind(this));
+    this._update(this.start, this.total);
   }
 
-  render() {
-    return html`
-      <button
-        type="button"
-        class="pb-paginate__nav"
-        data-page="first"
-        @click=${this._handleFirst}
-        aria-label=${translate('paginate.first')}
-      >
-        <pb-icon icon="chevron-left"></pb-icon>
-      </button>
-      ${this.pages.map(
-        (item, index) => html`
-          <button
-            type="button"
-            class="pb-paginate__page ${item.class}"
-            @click=${() => this._handleClick(item, index)}
-            aria-current=${item.class === 'active' ? 'page' : nothing}
-          >
-            ${item.label}
-          </button>
-        `,
-      )}
-      <button
-        type="button"
-        class="pb-paginate__nav"
-        data-page="last"
-        @click=${this._handleLast}
-        aria-label=${translate('paginate.last')}
-      >
-        <pb-icon icon="chevron-right"></pb-icon>
-      </button>
+  _update(start, total) {
+    if (!total || !start) {
+      return;
+    }
+    this.pageCount = Math.ceil(total / this.perPage);
+    this.page = Math.ceil(start / this.perPage);
 
-      <span class="found" part="count">${translate(this.foundLabel, { count: this.total })}</span>
-    `;
+    // If everything fits within range+2 slots, show all pages
+    if (this.pageCount <= this.range + 2) {
+      this.pages = Array.from({ length: this.pageCount }, (_, i) => ({
+        type: 'page',
+        label: i + 1,
+        class: i + 1 === this.page ? 'active' : '',
+      }));
+      return;
+    }
+
+    // Total slots = range + 2: page 1 (fixed) + range middle slots + last page (fixed).
+    // Middle slots hold a consecutive window plus up to 2 overflow markers.
+    // Core window size when both overflows are present = range - 2.
+    const coreSize = this.range - 2;
+
+    // Center core window around current page within [2, pageCount-1]
+    let winStart = this.page - Math.floor(coreSize / 2);
+    let winEnd = winStart + coreSize - 1;
+
+    if (winStart < 2) {
+      winStart = 2;
+      winEnd = winStart + coreSize - 1;
+    }
+    if (winEnd > this.pageCount - 1) {
+      winEnd = this.pageCount - 1;
+      winStart = Math.max(2, winEnd - coreSize + 1);
+    }
+
+    // Extend window when an overflow would hide ≤1 page, or reclaim freed overflow slot
+    if (winStart === 2) {
+      winEnd = Math.min(this.pageCount - 1, winEnd + 1);
+    } else if (winStart === 3) {
+      winStart = 2;
+    } else if (winEnd === this.pageCount - 1) {
+      winStart = Math.max(2, winStart - 1);
+    } else if (winEnd === this.pageCount - 2) {
+      winEnd = this.pageCount - 1;
+    }
+
+    /**
+     * @type {Overflow}
+     */
+    const overflow = { type: 'overflow' };
+    /** @type {PageOrOverflow[]} */
+    const pages = [];
+    pages.push({ type: 'page', label: 1, class: this.page === 1 ? 'active' : '' });
+    if (winStart > 2) {
+      pages.push(overflow);
+    }
+    for (let i = 0, l = winEnd - winStart + 1; i < l; i += 1) {
+      pages.push({
+        type: 'page',
+        label: winStart + i,
+        class: winStart + i === this.page ? 'active' : '',
+      });
+    }
+
+    if (winEnd < this.pageCount - 1) {
+      pages.push(overflow);
+    }
+    pages.push({
+      type: 'page',
+      label: this.pageCount,
+      class: this.page === this.pageCount ? 'active' : '',
+    });
+
+    this.pages = pages;
+  }
+
+  _refresh(ev) {
+    this.start = Number(ev.detail.start);
+    this.total = ev.detail.count;
+    this._update(this.start, this.total);
+  }
+
+  /**
+   * Go to a page
+   *
+   * @param {number} item
+   */
+  _handleClick(item) {
+    this.start = (item - 1) * this.perPage + 1;
+    ['pb-load', 'pb-paginate'].forEach(ev => {
+      this.emitTo(ev, {
+        params: {
+          start: this.start,
+          'per-page': this.perPage,
+          page: item,
+        },
+      });
+    });
+  }
+
+  /**
+   * Go to the first page in the pagination
+   */
+  _handleFirst() {
+    this.start = 1;
+    ['pb-load', 'pb-paginate'].forEach(event => {
+      this.emitTo(event, {
+        params: {
+          start: 1,
+          'per-page': this.perPage,
+          page: 0,
+        },
+      });
+    });
+  }
+
+  /**
+   * Go to the last page in the pagination
+   */
+  _handleLast() {
+    this.start = (this.pageCount - 1) * this.perPage + 1;
+    ['pb-load', 'pb-paginate'].forEach(event => {
+      this.emitTo(event, {
+        params: {
+          start: this.start,
+          'per-page': this.perPage,
+          page: this.pageCount - 1,
+        },
+      });
+    });
   }
 
   static get styles() {
@@ -151,36 +298,51 @@ export class PbPaginate extends pbMixin(LitElement) {
         gap: 8px;
       }
 
-      .pb-paginate__nav,
-      .pb-paginate__page {
-        padding: 4px 8px;
-        cursor: pointer;
-        border: none;
-        background: transparent;
-        color: inherit;
-        font: inherit;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
+      nav {
+        display: flex;
+        ul {
+          display: flex;
+          .pb-paginate__nav,
+          .pb-paginate__overflow,
+          .pb-paginate__page {
+            display: inherit;
+            flex: 1 0 auto;
+            height: 2.5rem;
+            justify-content: center;
+            margin-left: 0.25rem;
+            margin-right: 0.25rem;
+            background: transparent;
+            min-width: 2.5rem;
 
-      .pb-paginate__page.active {
-        background-color: var(--pb-color-primary);
-        color: var(--pb-color-inverse);
-        border-radius: 50%;
-        min-width: fit-content;
-        width: 1em;
-        line-height: 1em;
-        padding: 0.4em;
-        text-align: center;
-        box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 1px 8px 0 rgba(0, 0, 0, 0.12),
-          0 3px 3px -2px rgba(0, 0, 0, 0.4);
-      }
+            &:focus-visible {
+              outline: 2px solid var(--pb-color-primary);
+              outline-offset: 2px;
+            }
 
-      .pb-paginate__page:focus-visible,
-      .pb-paginate__nav:focus-visible {
-        outline: 2px solid var(--pb-color-primary);
-        outline-offset: 2px;
+            a.active {
+              border-radius: 50%;
+              box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 1px 8px 0 rgba(0, 0, 0, 0.12),
+                0 3px 3px -2px rgba(0, 0, 0, 0.4);
+              background-color: var(--pb-color-primary);
+              color: var(--pb-color-inverse);
+            }
+
+            &.pb-paginate__overflow span,
+            a {
+              /* Make them click areas nice and big */
+              padding: 0.5rem;
+              border-radius: 2.5rem;
+              color: var(--pb-color-primary);
+              display: inline-flex;
+              align-items: center;
+              text-decoration: none;
+            }
+          }
+        }
+        span {
+          display: flex;
+          align-items: center;
+        }
       }
 
       .found {
@@ -189,104 +351,74 @@ export class PbPaginate extends pbMixin(LitElement) {
     `;
   }
 
-  _update(start, total) {
-    if (!total || !start) {
-      return;
+  render() {
+    if (this.pages.length === 0) {
+      return '';
     }
-    this.pageCount = Math.ceil(total / this.perPage);
-    this.page = Math.ceil(start / this.perPage);
-    let lowerBound = Math.max(this.page - Math.ceil(this.range / 2) + 1, 1);
-    const upperBound = Math.min(lowerBound + this.range - 1, this.pageCount);
-    lowerBound = Math.max(upperBound - this.range + 1, 1);
-    console.log(
-      '<pb-paginate> start: %d, total: %d, perPage: %d, pageCount: %s, page: %d, lower: %d, upper: %d, range: %d, show-previous-next: %s',
-      start,
-      total,
-      this.perPage,
-      this.pageCount,
-      this.page,
-      lowerBound,
-      upperBound,
-      this.range, 
-      this.showPreviousNext
-    );
-    const pages = [];
-    const prevNextPages = []; //first item for previous control, second/last item for next control
-    for (let i = lowerBound; i <= upperBound; i++) {
-      pages.push({
-        label: i,
-        class: i === this.page ? 'active' : '',
-      });
-      if(!this.showPreviousNext) continue;
-      //previous page if it's first page
-      if(lowerBound === 1 && i === 1 && this.page === i) {
-        prevNextPages.push({
-          label: i,
-          index: 0
-        });
-      }
-      //previous page
-      if(i + 1 === this.page) {
-        prevNextPages.push({
-          label: i,
-          index: pages.length - 1
-        });
-      }
-      //next page
-      if(i - 1 === this.page) {
-        prevNextPages.push({
-          label: i,
-          index: pages.length - 1
-        });
-      }
-    }
-    this.pages = pages;
-    this.prevNextPages = prevNextPages;
-  }
 
-  _refresh(ev) {
-    this.start = Number(ev.detail.start);
-    this.total = ev.detail.count;
-    this._update(this.start, this.total);
-  }
+    const overflowPart = html`<li
+      class="pb-paginate__overflow"
+      aria-label="${translate('pagination.ellipsislabel')}"
+    >
+      <span>…</span>
+    </li>`;
 
-  _handleClick(_item, index) {
-    this.start = (this.pages[index].label - 1) * this.perPage + 1;
-    for (const ev of ['pb-load', 'pb-paginate']) {
-      this.emitTo(ev, {
-        params: {
-          start: this.start,
-          'per-page': this.perPage,
-          page: index,
-        },
-      });
-    }
-  }
-
-  _handleFirst() {
-    this.start = 1;
-    for (const ev of ['pb-load', 'pb-paginate']) {
-      this.emitTo(ev, {
-        params: {
-          start: 1,
-          'per-page': this.perPage,
-          page: 0,
-        },
-      });
-    }
-  }
-
-  _handleLast() {
-    this.start = (this.pageCount - 1) * this.perPage + 1;
-    for (const ev of ['pb-load', 'pb-paginate']) {
-      this.emitTo(ev, {
-        params: {
-          start: this.start,
-          'per-page': this.perPage,
-          page: this.pageCount - 1,
-        },
-      });
-    }
+    return html`
+      <nav aria-label="${translate('pagination.pagination')}">
+        <ul>
+          ${this.showPreviousNext
+            ? html`<li
+                class="pb-paginate__nav pb-paginate__nav-previous"
+                style="${this.page === 1 ? 'visibility: hidden' : ''}"
+              >
+                <a
+                  href="javascript:void(0);"
+                  aria-label="${translate('pagination.previous')}"
+                  @click="${() => this._handleClick(this.page - 1)}"
+                  ><pb-icon slot="previous-icon" icon="chevron-left"></pb-icon>
+                  <span><pb-i18n key="pagination.previous">Previous</pb-i18n></span>
+                </a>
+              </li>`
+            : nothing}
+          ${this.pages.map(item => {
+            switch (item.type) {
+              case 'overflow':
+                return overflowPart;
+              default:
+                return html`<li class="pb-paginate__page">
+                  <a
+                    href="javascript:void(0);"
+                    aria-label="${translate('pagination.page', { page: item.label })}"
+                    class="${item.class}"
+                    @click="${() => this._handleClick(item.label)}"
+                  >
+                    ${item.label}
+                  </a>
+                </li>`;
+            }
+          })}
+          ${this.showPreviousNext
+            ? html`<li
+                class="pb-paginate__nav pb-paginate__nav_next"
+                style="${
+                  // Use visibility: hidden to make sure we still take space for this. Makes the layout shift less
+                  this.page < this.pageCount ? '' : 'visibility: hidden'
+                }"
+              >
+                <a
+                  href="javascript:void(0);"
+                  aria-label="${translate('pagination.next')}"
+                  @click="${() => this._handleClick(this.page + 1)}"
+                >
+                  <span><pb-i18n key="pagination.next">Next</pb-i18n></span
+                  ><pb-icon slot="previous-icon" icon="chevron-right"></pb-icon>
+                </a>
+              </li>`
+            : nothing}
+        </ul>
+        <span class="found" part="count">${translate(this.foundLabel, { count: this.total })}</span>
+      </nav>
+    `;
   }
 }
 customElements.define('pb-paginate', PbPaginate);

--- a/src/pb-paginate.js
+++ b/src/pb-paginate.js
@@ -352,10 +352,6 @@ export class PbPaginate extends themableMixin(pbMixin(LitElement)) {
   }
 
   render() {
-    if (this.pages.length === 0) {
-      return '';
-    }
-
     const overflowPart = html`<li
       class="pb-paginate__overflow"
       aria-label="${translate('pagination.ellipsislabel')}"

--- a/src/theming.js
+++ b/src/theming.js
@@ -141,9 +141,15 @@ function getSelectors(component) {
  * Implements support for injecting user-defined styles into a web component's shadow DOM.
  * Styles will be copied from the global component theme CSS imported by `pb-page`
  * (see `theme` property on `pb-page`)
+ *
+ * @template {typeof import('lit-element').LitElement} T
+ * @param {T} BaseClass
  */
-export const themableMixin = superclass =>
-  class ThemableMixin extends superclass {
+export const themableMixin = BaseClass =>
+  /**
+   * @augments BaseClass
+   */
+  class ThemableMixin extends BaseClass {
     connectedCallback() {
       super.connectedCallback();
       waitOnce('pb-page-ready', options => {

--- a/test/cypress/component/pb-paginate.cy.js
+++ b/test/cypress/component/pb-paginate.cy.js
@@ -1,21 +1,190 @@
 // Cypress CT: pb-paginate
-import '../../../src/pb-paginate.js'
+import '../../../src/pb-paginate.js';
+
+/**
+ * @param {string} form - A form, like `[1,2,3*, 4, 5, ..., 10]`
+ * @return {(ele: JQuery<HTMLElement>) => void}
+ */
+function haveCorrectPageForm(form) {
+  const tokens = form
+    .substring(1, form.length - 1)
+    .split(',')
+    .map(str => str.trim());
+
+  /**
+   * @type {((ele: HTMLElement) => void)[]}
+   */
+  const asserts = tokens.map((token, i) => {
+    if (token === '...') {
+      return ele => {
+        expect(ele.matches('.pb-paginate__overflow'), `The page ${i} should be an overflow`).to.be
+          .true;
+      };
+    }
+
+    // Normal page
+    return ele => {
+      if (token.endsWith('*')) {
+        expect(ele.querySelector('.active'), `The page ${i} should be active`).to.exist;
+      } else {
+        expect(ele.querySelector('.active')).to.be.null;
+      }
+      const pageNo = token.endsWith('*')
+        ? parseInt(token.substring(0, token.length - 1), 10)
+        : parseInt(token, 10);
+      expect(ele.matches('.pb-paginate__page'), `The page ${i} should be a normal page`).to.be.true;
+      expect(ele.innerText.trim(), 'The page label should be correct').to.equal(`${pageNo}`);
+    };
+  });
+  return ([pbPaginate]) => {
+    const listItems = Array.from(pbPaginate.shadowRoot.querySelectorAll('li'));
+    expect(listItems).to.have.length(asserts.length + 2);
+
+    for (let i = 0; i < asserts.length; i += 1) {
+      const assertion = asserts[i];
+      const child = listItems[i + 1];
+      assertion(child);
+    }
+  };
+}
 
 describe('pb-paginate', () => {
   beforeEach(() => {
-    cy.mount('<pb-paginate id="pg" per-page="10"></pb-paginate>')
-  })
+    cy.mount('<pb-paginate id="pg" per-page="10"></pb-paginate>');
+  });
 
   it('should emit events when page is clicked after receiving results', () => {
     cy.get('#pg').then($el => {
-      const host = $el[0]
-      host._refresh({ detail: { start: 1, count: 30 } })
-      return host.updateComplete
-    })
-    cy.get('#pg').find('.pb-paginate__page').should('have.length', 3)
-    cy.get('#pg').find('.pb-paginate__page').contains('2').click()
+      const host = $el[0];
+      host._refresh({ detail: { start: 1, count: 30 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1*, 2, 3]'));
+
+    cy.get('#pg').find('.pb-paginate__page').contains('2').click();
     cy.get('#pg').then($el => {
-      expect($el[0].start).to.equal(11)
-    })
-  })
-})
+      expect($el[0].start).to.equal(11);
+    });
+  });
+
+  it('should show the correct pages when there are only two pages', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 1, count: 20 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1*, 2]'));
+  });
+
+  it('should show the correct pages when there are only two pages and the last one is active', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 15, count: 20 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2*]'));
+  });
+
+  it('should show the correct pages when there are only five pages and the last one is active', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 49, count: 50 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2, 3, 4, 5*]'));
+  });
+
+  it('should show the correct pages when there six pages and the last one is active', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 59, count: 60 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2, 3, 4, 5, 6*]'));
+  });
+
+  it('should show the correct pages when there seven pages and the last one is active', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 69, count: 70 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2, 3, 4, 5, 6, 7*]'));
+  });
+
+  it('should show the correct pages when there eight pages and the last one is active. Overflow kicks in', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 79, count: 80 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, ..., 4, 5, 6, 7, 8*]'));
+  });
+
+  it('should show the correct pages when there eight pages and the middle one is active. Overflow kicks in', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 40, count: 80 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2, 3, 4*, 5, ..., 8]'));
+  });
+
+  it('should show the correct pages when there eight pages and the middle one is active. Overflow kicks in', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 50, count: 80 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, ..., 4, 5*, 6, 7, 8]'));
+  });
+
+  it('should show the correct pages when the overflow should kick in', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 1, count: 100 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1*, 2, 3, 4, 5, ..., 10]'));
+  });
+
+  it('should show the correct pages when the overflow should kick in on both sides', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 50, count: 100 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, ...,4, 5*, 6, ..., 10]'));
+  });
+
+  it('should show the correct pages when the overflow just about did not kick in at the start', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 40, count: 100 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, 2, 3, 4*, 5, ..., 10]'));
+  });
+
+  it('should show the correct pages when the overflow just about did not kick in at the end', () => {
+    cy.get('#pg').then($el => {
+      const host = $el[0];
+      host._refresh({ detail: { start: 80, count: 100 } });
+      return host.updateComplete;
+    });
+
+    cy.get('#pg').should(haveCorrectPageForm('[1, ..., 6, 7, 8*, 9, 10]'));
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,12 @@
 const MOCK_VERSION = {
   api: '1.0.0',
   app: { name: 'mock-app', version: '0.0.0' },
-  engine: { name: 'mock-engine', version: '0.0.0' }
-}
+  engine: { name: 'mock-engine', version: '0.0.0' },
+};
 import { defineConfig } from 'vite';
 import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
 
 const isCypress = !!process.env.CYPRESS;
 
@@ -23,50 +25,86 @@ export default defineConfig({
       // Keep CORS relaxed for local eXist/dev interactions
       'Access-Control-Allow-Origin': '*',
     },
-    proxy: isCypress ? undefined : {
-      '/exist': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/demo/, ''),
-      },
+    proxy: {
+      ...(isCypress
+        ? {}
+        : {
+            '/exist': {
+              target: 'http://localhost:8080',
+              changeOrigin: true,
+              secure: false,
+              rewrite: path => path.replace(/^\/demo/, ''),
+            },
+          }),
     },
     // Ensure lib/ directory is served as static files
     fs: {
-      allow: ['..', '.', 'lib']
-    }
+      allow: ['..', '.', 'lib'],
+    },
   },
   plugins: [
+    {
+      name: 'redirect-localization',
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          const url = req.url || '';
+
+          if (url.startsWith('/demo/resources/i18n/common')) {
+            const languageFile = url.substring('/demo/resources/i18n/common'.length + 1);
+            console.log(languageFile);
+
+            try {
+              const text = await readFile(
+                join(module.path, 'i18n', 'common', basename(languageFile)),
+                'utf-8',
+              );
+
+              res.setHeader('content-type', 'application/json');
+              res.end(text);
+            } catch (e) {
+              res.statusCode = 404;
+              res.setHeader('content-type', 'text/plain');
+
+              res.end(e.toString());
+            }
+          }
+          next();
+        });
+      },
+    },
     {
       name: 'mock-teipublisher-handshake',
       configureServer(server) {
         server.middlewares.use((req, res, next) => {
-          const url = req.url || ''
+          const url = req.url || '';
           // Normalize both rooted and app-rooted paths
-          const isLogin = url.startsWith('/login') || url.startsWith('/exist/apps/tei-publisher/login')
-          const isVersion = url.startsWith('/api/version') || url.startsWith('/exist/apps/tei-publisher/api/version')
+          const isLogin =
+            url.startsWith('/login') || url.startsWith('/exist/apps/tei-publisher/login');
+          const isVersion =
+            url.startsWith('/api/version') ||
+            url.startsWith('/exist/apps/tei-publisher/api/version');
 
           if (isLogin) {
-            res.statusCode = 404
-            res.setHeader('content-type', 'text/plain')
-            res.end('Not Found')
-            return
+            res.statusCode = 404;
+            res.setHeader('content-type', 'text/plain');
+            res.end('Not Found');
+            return;
           }
           if (isVersion) {
-            res.statusCode = 200
-            res.setHeader('content-type', 'application/json')
-            res.end(JSON.stringify(MOCK_VERSION))
-            return
+            res.statusCode = 200;
+            res.setHeader('content-type', 'application/json');
+            res.end(JSON.stringify(MOCK_VERSION));
+            return;
           }
-          next()
-        })
-      }
+          next();
+        });
+      },
     },
   ],
   resolve: {
     alias: [
       // Normalize any accidental /node_modules path imports to bare package names
-    ]
+    ],
   },
   define: {
     'process.env.NODE_ENV': JSON.stringify('production'),
@@ -80,7 +118,7 @@ export default defineConfig({
       // keep heavy/legacy libs out of prebundle
       'gridjs',
       'hotkeys-js',
-      'construct-style-sheets-polyfill'
-    ]
+      'construct-style-sheets-polyfill',
+    ],
   },
 });


### PR DESCRIPTION
* Make it more accessible: better click areas
* Guide users: add overflow pages and show the total page count and enable easy navigation to the start / end
* Enable next and previous controls by default
* Add i18n localization to all user-facing strings
* Add more aria attributes
* Add a demo

* Make localization work again in demos when vite is the dev server

# How it looks now:
<img width="1411" height="1084" alt="image" src="https://github.com/user-attachments/assets/042888be-6130-40b8-9b41-778eb70ff3f1" />

# How it used to look: 

<img width="917" height="817" alt="image" src="https://github.com/user-attachments/assets/3c71a0c2-3ac3-4161-93ff-9f61ff085e18" />
