### PR TITLE
chore(tests): disable running E2E tests on actual back-end

### DIFF
--- a/.github/workflows/docker-cypress.yml
+++ b/.github/workflows/docker-cypress.yml
@@ -10,6 +10,14 @@ on:
 
 jobs:
   docker-cypress-e2e:
+    name: Run Cypress E2E tests on actual back-end
+    # Run E2E tests on the actual back-end. Boot up exist, install tei-publisher-app for the API
+    # implementations and run the E2E tests
+
+    # disabled until we reach a concensus on how to work with multiple versions of
+    # tei-publisher-components, exist db and tei-publisher-app
+    if: false
+
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
They are broken right now

@duncdrum in #318 you mentioned a meeting between yourself and @wolfgangmm. Has this taken place?

For now, the CI is known-broken. The existing E2E tests provide sufficient coverage.
Disable this until we have a way forward.