### PR TITLE
Optional client side hydration for pb-view

### DIFF
--- a/src/pb-navigation.js
+++ b/src/pb-navigation.js
@@ -1,11 +1,41 @@
 import { LitElement, html, css } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { pbMixin } from './pb-mixin.js';
 import { pbHotkeys } from './pb-hotkeys.js';
+
+/**
+ * Build a clean, canonical fragment URL for the current document: the current
+ * path plus `?id=` (persistent xml:id, preferred) or `?root=` (node id) as a
+ * fallback. Other query parameters are dropped so the link matches the
+ * canonical/sitemap URL. Returns null when there is no target.
+ *
+ * @param {string} id the target fragment's xml:id, if any
+ * @param {string} root the target fragment's node id, used when no xml:id exists
+ * @returns {string|null} the relative href, or null when there is no target
+ */
+function buildFragmentHref(id, root) {
+  if (!id && !root) {
+    return null;
+  }
+  const url = new URL(window.location.href);
+  url.search = '';
+  if (id) {
+    url.searchParams.set('id', id);
+  } else {
+    url.searchParams.set('root', root);
+  }
+  return url.pathname + url.search;
+}
 
 /**
  * Navigate backward/forward in a document. This component does not implement any functionality itself.
  * It just sends a `pb-navigate` event when clicked. You may also assign a shortcut key by setting property
  * `keyboard`.
+ *
+ * In addition to firing `pb-navigate`, the control renders a real `<a href>` pointing to the
+ * target fragment (`?id=` for a persistent xml:id, `?root=` as fallback) with `rel="next"`/`rel="prev"`.
+ * This makes the next/previous page reachable by crawlers and no-JS clients, while interactive
+ * clicks are intercepted (`preventDefault`) so the SPA navigates in place without a reload.
  *
  * @slot - default unnamed slot
  * @fires pb-navigate - Fire event indicating that listening components should navigate in the given direction
@@ -37,6 +67,14 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
       rendition: {
         type: String,
       },
+      /**
+       * Internal: the crawlable href pointing to the target fragment, recomputed
+       * from each `pb-update`.
+       */
+      _href: {
+        type: String,
+        attribute: false,
+      },
     };
   }
 
@@ -44,6 +82,7 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
     super();
     this.direction = 'forward';
     this.disabled = true;
+    this._href = null;
   }
 
   connectedCallback() {
@@ -70,25 +109,35 @@ export class PbNavigation extends pbHotkeys(pbMixin(LitElement)) {
   }
 
   _update(ev) {
+    const { data } = ev.detail;
     if (this.direction === 'forward') {
-      if (ev.detail.data.next) {
-        this.disabled = false;
-      } else {
-        this.disabled = true;
-      }
-    } else if (ev.detail.data.previous) {
-      this.disabled = false;
+      this.disabled = !data.next;
+      this._href = buildFragmentHref(data.nextId, data.next);
     } else {
-      this.disabled = true;
+      this.disabled = !data.previous;
+      this._href = buildFragmentHref(data.previousId, data.previous);
     }
   }
 
-  _handleClick() {
+  _handleClick(ev) {
+    // Crawlers and no-JS clients follow the real href; for interactive use we
+    // navigate in place via the pb-navigate event instead of reloading.
+    if (ev) {
+      ev.preventDefault();
+    }
     this.emitTo('pb-navigate', { direction: this.direction });
   }
 
   render() {
-    return html` <a id="button" @click="${this._handleClick}"><slot></slot></a> `;
+    return html`
+      <a
+        id="button"
+        href="${ifDefined(this._href || undefined)}"
+        rel="${this.direction === 'forward' ? 'next' : 'prev'}"
+        @click="${this._handleClick}"
+        ><slot></slot
+      ></a>
+    `;
   }
 
   static get styles() {

--- a/src/pb-view.js
+++ b/src/pb-view.js
@@ -650,6 +650,18 @@ export class PbView extends themableMixin(pbMixin(LitElement)) {
   _doLoad(params) {
     this.emitTo('pb-start-update', params);
 
+    // On the first load, check whether the server already rendered this
+    // fragment into our light DOM. If so, request only
+    // the navigation metadata (content=none) and adopt the existing markup
+    // instead of rendering the same content a second time.
+    if (this._ssrContent === undefined) {
+      this._ssrContent = this.querySelector(':scope > [data-pb-ssr]') || null;
+      this._ssrFootnotes = this.querySelector(':scope > [data-pb-ssr-footnotes]') || null;
+    }
+    if (this._ssrContent) {
+      params.content = 'none';
+    }
+
     console.log('<pb-view> Loading view with params %o', params);
     if (!this.infiniteScroll) {
       this._clear();
@@ -709,9 +721,7 @@ export class PbView extends themableMixin(pbMixin(LitElement)) {
 
     const index = await fetch(`index.json`).then(response => response.json());
     const paramNames = ['odd', 'view', 'xpath', 'map'];
-    this.querySelectorAll('pb-param').forEach(param =>
-      paramNames.push(`user.${param.getAttribute('name')}`),
-    );
+    this._params().forEach(param => paramNames.push(`user.${param.getAttribute('name')}`));
     let url = params.id ? createKey([...paramNames, 'id']) : createKey([...paramNames, 'root']);
     let file = index[url];
     if (!file) {
@@ -827,7 +837,17 @@ export class PbView extends themableMixin(pbMixin(LitElement)) {
     const elem = document.createElement('div');
     // elem.style.opacity = 0; //hide it - animation has to make sure to blend it in
     fragment.appendChild(elem);
-    elem.innerHTML = resp.content;
+    if (this._ssrContent && (!resp.content || resp.content.length === 0)) {
+      // Adopt the server-rendered content from light DOM (SSR) rather than
+      // re-rendering it: move its children into the shadow content container.
+      while (this._ssrContent.firstChild) {
+        elem.appendChild(this._ssrContent.firstChild);
+      }
+      this._ssrContent.remove();
+      this._ssrContent = null;
+    } else {
+      elem.innerHTML = resp.content;
+    }
 
     // if before-update-event is set, we do not replace the content immediately,
     // but emit an event
@@ -889,10 +909,22 @@ export class PbView extends themableMixin(pbMixin(LitElement)) {
 
     if (this.appendFootnotes) {
       const footnotes = document.createElement('div');
-      if (resp.footnotes) {
+      if (this._ssrFootnotes) {
+        // Adopt the server-rendered footnotes from light DOM (SSR).
+        while (this._ssrFootnotes.firstChild) {
+          footnotes.appendChild(this._ssrFootnotes.firstChild);
+        }
+      } else if (resp.footnotes) {
         footnotes.innerHTML = resp.footnotes;
       }
       this._footnotes = footnotes;
+    }
+    // Drop the SSR footnotes marker even when not appending, so it does not
+    // linger in the light DOM (matches the dynamic path, which ignores
+    // footnotes unless append-footnotes is set).
+    if (this._ssrFootnotes) {
+      this._ssrFootnotes.remove();
+      this._ssrFootnotes = null;
     }
 
     this._initFootnotes(this._footnotes);
@@ -1013,9 +1045,20 @@ export class PbView extends themableMixin(pbMixin(LitElement)) {
     }
   }
 
+  /**
+   * Collect the configuration `pb-param` children of this view. Excludes any
+   * `pb-param` that may occur inside server-rendered (SSR) content adopted into
+   * the light DOM, so injected content can never be mistaken for a parameter.
+   */
+  _params() {
+    return Array.from(this.querySelectorAll('pb-param')).filter(
+      param => !param.closest('[data-pb-ssr], [data-pb-ssr-footnotes]'),
+    );
+  }
+
   _getParameters() {
     const params = [];
-    this.querySelectorAll('pb-param').forEach(param => {
+    this._params().forEach(param => {
       params[`user.${param.getAttribute('name')}`] = param.getAttribute('value');
     });
     // add parameters for features set with pb-toggle-feature


### PR DESCRIPTION
* server may pre-render first document fragment into light dom – if present, `pb-view` uses it and only retrieves metadata via API: avoids redundant rendering via ODD
* `pb-navigation`: output a canonical link, discoverable by googlebot