### PR TITLE
Feature/reconcile

### DIFF
--- a/i18n/common/de.json
+++ b/i18n/common/de.json
@@ -252,6 +252,7 @@
   },
   "annotations": {
     "edit": "Annotation ändern",
+    "cancel": "Abbrechen",
     "delete": "Annotation löschen",
     "save": "Änderungen ins TEI speichern",
     "no-properties": "Keine Eigenschaften vorhanden.",

--- a/i18n/common/en.json
+++ b/i18n/common/en.json
@@ -333,6 +333,7 @@
     "status": "Status",
     "enrichment": "Enrichment",
     "details": "Annotation Details",
+    "cancel": "Cancel",
     "hi-bold": "bold",
     "hi-i": "italic",
     "markup": "Inline text/markup or sequence of paragraphs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@polymer/paper-tooltip": "^3.0.1",
         "@vaadin/vaadin-tabs": "^3.2.0",
         "@vaadin/vaadin-upload": "^4.4.0",
-        "@webcomponents/webcomponentsjs": "*",
+        "@webcomponents/webcomponentsjs": "latest",
         "airtable": "^0.12.2",
         "animejs": "^3.2.0",
         "browser-fs-access": "^0.34.1",

--- a/src/authority/connectors.js
+++ b/src/authority/connectors.js
@@ -7,6 +7,19 @@ import { Anton } from './anton.js';
 import { ReconciliationService } from './reconciliation.js';
 import { Custom } from './custom.js';
 
+/**
+ * Instantiate one connector per direct `<pb-authority connector="...">` child of `root`
+ * (typically a `<pb-authority-lookup>` or, when called from custom.js, a `<pb-authority
+ * connector="Custom">` wrapping further nested authorities). `endpoint` is only used by
+ * "Custom", which talks to this app's own local register API rather than an external service.
+ *
+ * The `connector` attribute is matched by exact string, case-sensitively, against a fixed
+ * list - anything that doesn't match (including a typo, e.g. "Reconciliation" instead of
+ * "ReconciliationService") falls through to `default` and silently becomes a Metagrid
+ * connector instead of failing loudly. There's no validation surfacing this at config time; a
+ * misconfigured `connector` attribute looks like a working authority that just happens to
+ * query the wrong (Metagrid) service.
+ */
 export function createConnectors(endpoint, root) {
   const authorities = [];
   root.querySelectorAll(':scope > pb-authority').forEach(configElem => {

--- a/src/authority/connectors.js
+++ b/src/authority/connectors.js
@@ -14,11 +14,13 @@ import { Custom } from './custom.js';
  * "Custom", which talks to this app's own local register API rather than an external service.
  *
  * The `connector` attribute is matched by exact string, case-sensitively, against a fixed
- * list - anything that doesn't match (including a typo, e.g. "Reconciliation" instead of
- * "ReconciliationService") falls through to `default` and silently becomes a Metagrid
- * connector instead of failing loudly. There's no validation surfacing this at config time; a
- * misconfigured `connector` attribute looks like a working authority that just happens to
- * query the wrong (Metagrid) service.
+ * list; `"Metagrid"` is itself one of the valid names, not just the fallback. Anything else
+ * (including a typo, e.g. "Reconciliation" instead of "ReconciliationService") still becomes
+ * a Metagrid connector - changing that to skip the entry or throw risks either silently
+ * dropping a configured authority or crashing an entire federated Custom search over one bad
+ * nested connector, neither obviously better than today's behaviour - but it is no longer
+ * silent: an unrecognized name is logged loudly so the mistake is visible in devtools instead
+ * of just looking like a working authority that happens to query the wrong service.
  */
 export function createConnectors(endpoint, root) {
   const authorities = [];
@@ -48,7 +50,16 @@ export function createConnectors(endpoint, root) {
       case 'Custom':
         instance = new Custom(endpoint, configElem);
         break;
+      case 'Metagrid':
+        instance = new Metagrid(configElem);
+        break;
       default:
+        console.error(
+          '<pb-authority> connector="%s" is not a recognized connector name - falling back to Metagrid. ' +
+            'Check for a typo (the exact, case-sensitive names are GND, GeoNames, Airtable, KBGA, Anton/GF, ' +
+            'ReconciliationService, Custom, Metagrid).',
+          connector,
+        );
         instance = new Metagrid(configElem);
         break;
     }

--- a/src/authority/custom.js
+++ b/src/authority/custom.js
@@ -130,4 +130,26 @@ export class Custom extends Registry {
       return Promise.reject(Error(response.status.toString()));
     });
   }
+
+  /**
+   * Delegate to whichever wrapped sub-connector actually implements data-extension fetching (e.g.
+   * a nested ReconciliationService), mirroring how select() above already delegates getRecord() -
+   * without this, an `extend:propId` field source in this connector's own `fields` config would
+   * silently always resolve to "no value" for every item, since Registry's own default
+   * fetchExtend() is a no-op and Custom itself has no extend capability of its own.
+   *
+   * @param {string} id the id to fetch extended properties for
+   * @param {string[]} propertyIds the property ids to fetch
+   * @returns {Promise<Object.<string, *>>} promise resolving to a map of propertyId -> value
+   */
+  async fetchExtend(id, propertyIds) {
+    for (const connector of this._connectors) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await connector.fetchExtend(id, propertyIds).catch(() => ({}));
+      if (result && Object.keys(result).length > 0) {
+        return result;
+      }
+    }
+    return {};
+  }
 }

--- a/src/authority/custom.js
+++ b/src/authority/custom.js
@@ -2,6 +2,15 @@ import { Registry } from './registry.js';
 // eslint-disable-next-line import/no-cycle
 import { createConnectors } from './connectors.js';
 
+/**
+ * Combines this app's own local register with one or more nested connectors (configured as
+ * child <pb-authority> elements, see connectors.js's createConnectors()) into a single
+ * federated authority: search hits from both sources, viewing/selecting an entry prefers the
+ * local register copy but falls back to whichever nested connector actually has the data, and
+ * selecting an external (non-local) match copies it into the local register so it becomes an
+ * editable, citable local entry from then on. This is what lets e.g. "person" search GND and a
+ * reconciliation service alongside the local KBGA register with one unified candidate list.
+ */
 export class Custom extends Registry {
   constructor(endpoint, configElem) {
     super(configElem);
@@ -22,6 +31,12 @@ export class Custom extends Registry {
     return this._editable;
   }
 
+  /**
+   * Search the local register first, then every nested connector in turn, merging all results
+   * into one list. A nested-connector hit whose id already appeared in the local results is
+   * dropped (`localResults`) so the same entity doesn't show up twice just because it's both
+   * registered locally and independently findable via e.g. GND.
+   */
   async query(key) {
     return new Promise(resolve => {
       fetch(
@@ -58,6 +73,12 @@ export class Custom extends Registry {
     });
   }
 
+  /**
+   * Look up `key` in the local register first; only if that 404s (not registered locally, e.g.
+   * an id copied straight out of a search result the user hasn't selected/saved yet) does it
+   * fall through to asking each nested connector's own info() in turn, so a match that only
+   * exists externally still gets a working preview.
+   */
   info(key, container) {
     if (!key) {
       return Promise.resolve({});
@@ -96,6 +117,12 @@ export class Custom extends Registry {
   }
 
   /**
+   * Called when the user picks a candidate from the merged query() list. If `item` came from a
+   * nested connector rather than the local register, fetch its full record (first connector
+   * whose getRecord() succeeds - see the id-prefix caveat on ReconciliationService/GND's own
+   * getRecord()) and POST it into the local register's own API, turning a one-off external match
+   * into a permanent, editable local entry. If no nested connector can produce a record (e.g.
+   * `item` was already a local-register result), just pass it through unchanged.
    *
    * @param {any} item
    * @returns {Promise}

--- a/src/authority/geonames.js
+++ b/src/authority/geonames.js
@@ -1,5 +1,13 @@
 import { Registry } from './registry.js';
 
+// Illustrative placeholder only - a generic location-pin icon, not fetched from GeoNames (which
+// has no depiction/image field of its own) - demonstrates that a connector's own info() preview
+// can include a thumbnail image the same way the reconcile profile's server-rendered /preview
+// does for reconciliation-service-backed types, even for a connector that renders its own bespoke
+// HTML rather than going through that server-side mechanism at all.
+const PLACE_ICON =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MCIgaGVpZ2h0PSI4MCIgdmlld0JveD0iMCAwIDYwIDgwIj48cGF0aCBkPSJNMzAgMkMxNCAyIDIgMTQgMiAzMGMwIDIyIDI4IDQ4IDI4IDQ4czI4LTI2IDI4LTQ4QzU4IDE0IDQ2IDIgMzAgMnoiIGZpbGw9IiNjMDM5MmIiLz48Y2lyY2xlIGN4PSIzMCIgY3k9IjMwIiByPSIxMiIgZmlsbD0iI2ZmZiIvPjwvc3ZnPg==';
+
 export class GeoNames extends Registry {
   constructor(configElem) {
     super(configElem);
@@ -49,6 +57,7 @@ export class GeoNames extends Registry {
             return;
           }
           const output = `
+            <img src="${PLACE_ICON}" alt="" style="max-width:100%; max-height:8em;"/>
             <h3 class="label">
               <a href="${json.link}" target="_blank">${json.name}</a>
             </h3>
@@ -89,12 +98,45 @@ export class GeoNames extends Registry {
         output.country = json.countryName;
         output.region = json.adminName1;
         output.note = json.fcodeName;
-        output.links = [
-          `https://www.geonames.org/${json.geonameId}`,
-          `https://${json.wikipediaURL}`,
-        ];
+        output.link = `https://www.geonames.org/${json.geonameId}`;
+        output.links = [output.link, `https://${json.wikipediaURL}`];
+        if (json.lat && json.lng) {
+          output.geo = `${json.lat},${json.lng}`;
+        }
         return output;
       })
       .catch(() => Promise.reject());
+  }
+
+  /**
+   * Fetch additional property values for a single matched entry beyond what query() already
+   * returned, using the same normalized record getRecord() already builds (region/country/note/
+   * link/geo) - lets a `fields` mapping's `extend:propId` source resolve for a GeoNames-backed
+   * match the same way it already does for a reconciliation-service-backed one, via
+   * Registry.buildProperties (this override is what makes Custom.fetchExtend's own delegation to
+   * wrapped connectors actually find something, instead of always silently resolving to "no
+   * value").
+   *
+   * @param {string} id the id to fetch extended properties for
+   * @param {string[]} propertyIds the property ids to fetch
+   * @returns {Promise<Object.<string, *>>} promise resolving to a map of propertyId -> value
+   */
+  async fetchExtend(id, propertyIds) {
+    try {
+      const record = await this.getRecord(id);
+      const result = {};
+      propertyIds.forEach(propId => {
+        let value = record[propId];
+        if (Array.isArray(value)) {
+          value = value.filter(Boolean).join('; ');
+        }
+        if (value !== undefined && value !== null && value !== '') {
+          result[propId] = value;
+        }
+      });
+      return result;
+    } catch (e) {
+      return {};
+    }
   }
 }

--- a/src/authority/geonames.js
+++ b/src/authority/geonames.js
@@ -80,6 +80,9 @@ export class GeoNames extends Registry {
    * @returns {Promise<any>} promise resolving to the JSON record returned by the endpoint
    */
   async getRecord(key) {
+    // Assumes `key` actually carries this connector's own prefix (see the equivalent, more
+    // fully-explained _stripPrefix() in reconciliation.js) - a `key` sourced from elsewhere
+    // (the local register, a differently-prefixed nested connector) would be sliced wrong.
     const id = this._prefix ? key.substring(this._prefix.length + 1) : key;
     return fetch(
       `https://secure.geonames.org/getJSON?geonameId=${encodeURIComponent(id)}&username=${
@@ -98,6 +101,12 @@ export class GeoNames extends Registry {
         output.country = json.countryName;
         output.region = json.adminName1;
         output.note = json.fcodeName;
+        // Singular "link" is what a `fields="...=extend:link"` mapping reads (see fetchExtend()
+        // below and Registry.buildProperties) - it was missing before, silently making that
+        // source always resolve to nothing for GeoNames matches. Plural "links" is this
+        // codebase's existing multi-link convention shared with the other connectors
+        // (metagrid.js, anton.js, kbga.js); kept alongside "link" for consistency even though
+        // nothing currently reads it back out.
         output.link = `https://www.geonames.org/${json.geonameId}`;
         output.links = [output.link, `https://${json.wikipediaURL}`];
         if (json.lat && json.lng) {

--- a/src/authority/gnd.js
+++ b/src/authority/gnd.js
@@ -90,6 +90,9 @@ export class GND extends Registry {
    * @returns {Promise<any>} promise resolving to the JSON record returned by the endpoint
    */
   async getRecord(key) {
+    // Assumes `key` actually carries this connector's own prefix (see the equivalent, more
+    // fully-explained _stripPrefix() in reconciliation.js) - a `key` sourced from elsewhere
+    // (the local register, a differently-prefixed nested connector) would be sliced wrong.
     const id = this._prefix ? key.substring(this._prefix.length + 1) : key;
     return fetch(`https://lobid.org/gnd/${id}.json`)
       .then(response => {

--- a/src/authority/gnd.js
+++ b/src/authority/gnd.js
@@ -102,6 +102,13 @@ export class GND extends Registry {
         const output = { ...json };
         output.name = json.preferredName;
         output.link = json.id;
+        // Alias for "link" matching the reconcile profile's own "gnd" data-extension
+        // property id (see reconc-config.xql) - lets an `extend:gnd` field mapping
+        // resolve the same GND URI whether the match came directly from this GND
+        // connector or from a nested ReconciliationService connector answering the
+        // same request (Custom.fetchExtend tries each in turn with the same property
+        // ids, see custom.js).
+        output.gnd = json.id;
         if (json.dateOfBirth && json.dateOfBirth.length > 0) {
           output.birth = json.dateOfBirth[0];
         }

--- a/src/authority/gnd.js
+++ b/src/authority/gnd.js
@@ -1,6 +1,14 @@
 /* eslint-disable class-methods-use-this */
 import { Registry } from './registry.js';
 
+// Illustrative placeholder only - a generic book icon, not fetched from GND (which has no
+// depiction/image field of its own) - demonstrates that a connector's own info() preview can
+// include a thumbnail image the same way the reconcile profile's server-rendered /preview does
+// for reconciliation-service-backed types, even for a connector that renders its own bespoke HTML
+// rather than going through that server-side mechanism at all.
+const WORK_ICON =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSI3MCIgdmlld0JveD0iMCAwIDgwIDcwIj48cmVjdCB4PSI0IiB5PSI4IiB3aWR0aD0iMzQiIGhlaWdodD0iNTQiIHJ4PSIzIiBmaWxsPSIjMjk4MGI5Ii8+PHJlY3QgeD0iNDIiIHk9IjgiIHdpZHRoPSIzNCIgaGVpZ2h0PSI1NCIgcng9IjMiIGZpbGw9IiMyNDcxYTMiLz48cmVjdCB4PSI4IiB5PSIxNCIgd2lkdGg9IjI2IiBoZWlnaHQ9IjQiIGZpbGw9IiNmZmYiLz48cmVjdCB4PSI4IiB5PSIyMiIgd2lkdGg9IjI2IiBoZWlnaHQ9IjQiIGZpbGw9IiNmZmYiLz48cmVjdCB4PSI0NiIgeT0iMTQiIHdpZHRoPSIyNiIgaGVpZ2h0PSI0IiBmaWxsPSIjZmZmIi8+PHJlY3QgeD0iNDYiIHk9IjIyIiB3aWR0aD0iMjYiIGhlaWdodD0iNCIgZmlsbD0iI2ZmZiIvPjwvc3ZnPg==';
+
 function _details(item) {
   let professions = '';
   if (item.professionOrOccupation && item.professionOrOccupation.length > 0) {
@@ -124,7 +132,10 @@ export class GND extends Registry {
           } else if (json.type.indexOf('AuthorityResource') > -1) {
             info = this.infoPerson(json);
           }
+          const icon =
+            this._register === 'work' ? `<img src="${WORK_ICON}" alt="" style="max-width:100%; max-height:8em;"/>` : '';
           const output = `
+          ${icon}
           <h3 class="label">
             <a href="https://${json.id}" target="_blank"> ${json.preferredName} </a>
           </h3>
@@ -154,5 +165,37 @@ export class GND extends Registry {
       return `<p>${terms.join(', ')}</p>`;
     }
     return '';
+  }
+
+  /**
+   * Fetch additional property values for a single matched entry beyond what query() already
+   * returned, using the same normalized record getRecord() already builds (link/note/profession/
+   * birth/death) - lets a `fields` mapping's `extend:propId` source resolve for a GND-backed match
+   * the same way it already does for a reconciliation-service-backed one, via
+   * Registry.buildProperties (this override is what makes Custom.fetchExtend's own delegation to
+   * wrapped connectors actually find something, instead of always silently resolving to "no
+   * value").
+   *
+   * @param {string} id the id to fetch extended properties for
+   * @param {string[]} propertyIds the property ids to fetch
+   * @returns {Promise<Object.<string, *>>} promise resolving to a map of propertyId -> value
+   */
+  async fetchExtend(id, propertyIds) {
+    try {
+      const record = await this.getRecord(id);
+      const result = {};
+      propertyIds.forEach(propId => {
+        let value = record[propId];
+        if (Array.isArray(value)) {
+          value = value.filter(Boolean).join('; ');
+        }
+        if (value !== undefined && value !== null && value !== '') {
+          result[propId] = value;
+        }
+      });
+      return result;
+    } catch (e) {
+      return {};
+    }
   }
 }

--- a/src/authority/kbga.js
+++ b/src/authority/kbga.js
@@ -54,6 +54,12 @@ export class KBGA extends Registry {
               register: this._register,
               id: this._prefix ? `${this._prefix}:${item['full-id']}` : item['full-id'],
               label: typeof label === 'string' ? item[label] : label(item),
+              // Only the bibl/songs "asHtml" field is real, KBGA-formatted markup (e.g.
+              // italicized titles) meant to be rendered as-is - see
+              // pb-authority-lookup.js's _formatItem, which only calls lit-html's
+              // unsafeHTML() when this flag is set. Every other register's label is a
+              // plain string and must stay auto-escaped.
+              labelIsHtml: label === 'asHtml',
               details: `${item['full-id']}`,
               link: `https://meta.karl-barth.ch/${register}/${item.id}`,
               strings: [typeof label === 'string' ? item[label] : label(item)],

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -1,34 +1,128 @@
 /* eslint-disable class-methods-use-this */
 import { Registry } from './registry.js';
 
-// Todo:
-// - strings <- types
-// - use scheme#types in @type output?
-// - test with other providers, inside custom connector
-// - documentation
+/**
+ * A tiny subset of the Reconciliation Service API (https://reconciliation-api.github.io/specs/)
+ * that this connector needs to speak, covering both the 0.2 and 1.0-draft protocol
+ * versions. The two differ in query batch shape, result batch shape, and how a
+ * manifest advertises its `view`/`preview` URL templates.
+ */
 
 async function getServiceManifest(endpoint) {
   const response = await fetch(endpoint);
-  const data = await response.json();
-  return data;
+  if (!response.ok) {
+    throw new Error(`Reconciliation service manifest request failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+/**
+ * Decide which protocol version to speak to this service.
+ *
+ * Prefer the most recent version the manifest's `versions` array advertises. Some
+ * real-world 0.2 services omit `versions` entirely (it only became mandatory with
+ * 1.0-draft), so fall back to sniffing the manifest shape: 1.0-draft requires a
+ * `view` object, 0.2 requires `identifierSpace`/`schemaSpace`.
+ */
+function detectVersion(manifest) {
+  const versions = Array.isArray(manifest?.versions) ? manifest.versions : [];
+  if (versions.includes('1.0-draft') || versions.includes('1.0')) {
+    return '1.0-draft';
+  }
+  if (versions.includes('0.2') || versions.includes('0.1')) {
+    return '0.2';
+  }
+  if (manifest?.identifierSpace || manifest?.schemaSpace) {
+    return '0.2';
+  }
+  return '1.0-draft';
+}
+
+/**
+ * Replace a manifest URL template's id placeholder, whether written as the strict
+ * 0.2 `{{id}}` or the looser 1.0-draft `{id}`/`{...id...}` pattern.
+ */
+function expandUrlTemplate(template, id) {
+  const encoded = encodeURIComponent(id);
+  if (template.includes('{{id}}')) {
+    return template.replace('{{id}}', encoded);
+  }
+  return template.replace(/\{[^{}]*id[^{}]*\}/, encoded);
+}
+
+function buildQueryOneDraft(key, type, limit) {
+  const query = {
+    conditions: [{ matchType: 'name', propertyValue: key }],
+  };
+  if (type) query.type = type;
+  if (limit) query.limit = Number(limit);
+  return {
+    init: {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ queries: [query] }),
+    },
+  };
+}
+
+function buildQueryZeroTwo(key, type, limit) {
+  const query = { query: key };
+  if (type) query.type = type;
+  if (limit) query.limit = Number(limit);
+  return {
+    init: {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ queries: JSON.stringify({ q0: query }) }),
+    },
+  };
+}
+
+/**
+ * Extract the ordered list of candidates from a result batch, regardless of
+ * protocol version: 1.0-draft returns `{ results: [{ candidates }] }` (one entry
+ * per submitted query, in order — this connector always submits exactly one);
+ * 0.2 returns `{ q0: { result } }` (keyed by the query id we chose, "q0").
+ */
+function extractCandidates(version, json) {
+  if (version === '1.0-draft') {
+    return json?.results?.[0]?.candidates ?? [];
+  }
+  return json?.q0?.result ?? [];
 }
 
 export class ReconciliationService extends Registry {
   constructor(configElem) {
     super(configElem);
     this.endpoint = configElem.getAttribute('endpoint');
-    this.debug = configElem.getAttribute('debug');
-    getServiceManifest(this.endpoint).then(result => {
-      this.ORConfig = result;
-      if (this.debug) {
-        console.log(
-          "OpenReconcile connector for register '%s' at endpoint <%s>. Using config: %o",
-          this._register,
-          this.endpoint,
-          this.ORConfig,
-        );
-      }
-    });
+    this.debug = configElem.hasAttribute('debug');
+    this.type = configElem.getAttribute('type') || this._register;
+    this.limit = configElem.getAttribute('limit');
+    this._manifestReady = getServiceManifest(this.endpoint)
+      .then(manifest => {
+        this.manifest = manifest;
+        this.version = detectVersion(manifest);
+        if (this.debug) {
+          console.log(
+            "Reconciliation connector for register '%s' at <%s>: negotiated version '%s'. Manifest: %o",
+            this._register,
+            this.endpoint,
+            this.version,
+            manifest,
+          );
+        }
+      })
+      .catch(error => {
+        console.error('Failed to load reconciliation service manifest from %s: %o', this.endpoint, error);
+        this.manifest = {};
+        this.version = '1.0-draft';
+      });
   }
 
   /**
@@ -37,56 +131,45 @@ export class ReconciliationService extends Registry {
    * @param {String} key the search string
    */
   async query(key) {
-    const results = [];
-    const paramsObj = {
-      q1: {
-        query: key,
-      },
-    };
+    await this._manifestReady;
+    const { init } = this.version === '1.0-draft'
+      ? buildQueryOneDraft(key, this.type, this.limit)
+      : buildQueryZeroTwo(key, this.type, this.limit);
 
-    return new Promise(resolve => {
-      fetch(this.endpoint, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: 'queries='.concat(JSON.stringify(paramsObj)),
-      })
-        .then(response => response.json())
-        .then(json => {
-          json.q1.result.forEach(item => {
-            if (this.ORConfig.view) {
-              this.view = this.ORConfig.view.url.replace('{{id}}', item.id);
-            } else {
-              this.view = item.id;
-            }
-            if (item.description) {
-              this.description = item.description;
-            } else if (item.type) {
-              this.description = item.type.map(t => t.name.toString()).join(', ');
-            } else {
-              this.description = '';
-            }
-            const result = {
-              register: this._register,
-              id: this._prefix ? `${this._prefix}-${item.id}` : item.id,
-              label: item.name,
-              link: this.view,
-              details: this.description,
-              provider: 'OpenReconcile',
-            };
-            results.push(result);
-          });
-          if (this.debug) {
-            console.log('OpenReconcile results: %o', results);
-          }
-          resolve({
-            totalItems: json.q1.result.length,
-            items: results,
-          });
-        });
+    const response = await fetch(this.endpoint, init);
+    if (!response.ok) {
+      throw new Error(`Reconciliation query failed: ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json();
+    const candidates = extractCandidates(this.version, json);
+
+    const results = candidates.map(item => {
+      let details;
+      if (item.description) {
+        details = item.description;
+      } else if (Array.isArray(item.type)) {
+        details = item.type.map(t => (typeof t === 'string' ? t : t.name)).join(', ');
+      } else {
+        details = '';
+      }
+      const link = this.manifest?.view?.url ? expandUrlTemplate(this.manifest.view.url, item.id) : item.id;
+      return {
+        register: this._register,
+        id: this._prefix ? `${this._prefix}-${item.id}` : item.id,
+        label: item.name,
+        link,
+        details,
+        provider: 'Reconciliation',
+      };
     });
+
+    if (this.debug) {
+      console.log('Reconciliation results (%s): %o', this.version, results);
+    }
+    return {
+      totalItems: results.length,
+      items: results,
+    };
   }
 
   /**
@@ -97,27 +180,40 @@ export class ReconciliationService extends Registry {
    * @param {HTMLElement} container reference to an element which should be used as container for displaying the information
    * @returns {Promise} a promise
    */
-  info(id, container) {
+  async info(id, container) {
     if (!id) {
-      return Promise.resolve({});
+      return {};
     }
-    if (!this.ORConfig.preview) {
-      container.innerHTML = "no 'preview' information in endpoint's manifest";
-      return Promise.resolve();
+    await this._manifestReady;
+    const rawId = this._prefix ? id.substring(this._prefix.length + 1) : id;
+
+    // 1.0-draft only requires manifest.preview to carry width/height, not a url — the
+    // preview page itself lives at the fixed "<endpoint>/preview?id=..." sub-path.
+    // Some services (incl. our own reconcile profile) also emit preview.url directly,
+    // for both versions; prefer it when present, else fall back to the 1.0-draft
+    // convention, else give up gracefully.
+    let previewUrl;
+    if (this.manifest?.preview?.url) {
+      previewUrl = expandUrlTemplate(this.manifest.preview.url, rawId);
+    } else if (this.manifest?.preview && this.version === '1.0-draft') {
+      previewUrl = `${this.endpoint.replace(/\/$/, '')}/preview?id=${encodeURIComponent(rawId)}`;
     }
 
-    return new Promise((resolve, reject) => {
-      const rawid = this._prefix ? id.substring(this._prefix.length + 1) : id;
-      const url = this.ORConfig.preview.url.replace('{{id}}', encodeURIComponent(rawid));
-      fetch(url)
-        .then(response => response.text())
-        .then(output => {
-          container.innerHTML = output;
-          resolve({
-            id: this._prefix ? `${this._prefix}-${rawid}` : rawid,
-          });
-        })
-        .catch(() => reject());
-    });
+    if (!previewUrl) {
+      container.innerHTML = "no 'preview' information in endpoint's manifest";
+      return {};
+    }
+
+    try {
+      const response = await fetch(previewUrl);
+      const output = await response.text();
+      container.innerHTML = output;
+      return {
+        id: this._prefix ? `${this._prefix}-${rawId}` : rawId,
+      };
+    } catch (error) {
+      container.innerHTML = 'failed to load preview';
+      throw error;
+    }
   }
 }

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -186,6 +186,14 @@ export class ReconciliationService extends Registry {
    * back the raw id this service itself actually knows about. Needed anywhere a raw id must be
    * sent back to the service - info()'s preview lookup already did this inline; fetchExtend()/
    * getRecord() below reuse the same logic rather than duplicating the substring arithmetic.
+   *
+   * Assumes `id` actually carries this connector's own prefix - it blindly chops off
+   * `this._prefix.length + 1` characters regardless of what's actually there. Custom's
+   * federated query() (custom.js) can hand this connector an id that came from a different
+   * nested connector or the local register instead, and this method has no way to detect that
+   * mismatch; it just returns a garbage substring. Callers that got the id from somewhere other
+   * than this connector's own query() should not assume _stripPrefix()/fetchExtend()/getRecord()
+   * will do anything sensible with it.
    */
   _stripPrefix(id) {
     return this._prefix ? id.substring(this._prefix.length + 1) : id;

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -392,6 +392,16 @@ export class ReconciliationService extends Registry {
     const proposed = await proposeResponse.json();
     const propertyIds = (proposed?.properties || []).map(p => p.id);
     const values = propertyIds.length > 0 ? await this.fetchExtend(id, propertyIds) : {};
+    // TEI Publisher's own registers.xql (rapi:create-record/rapi:normalize-gender) expects a
+    // "gender" property to be an array of {id, label} objects (matching GND's vocabulary shape,
+    // e.g. id: "https://d-nb.info/standards/vocab/gnd/gender#male") and crashes with a bare
+    // XPTY0004 if it's a plain string instead - which is exactly what a generic reconciliation
+    // service's /extend response gives us (see extractExtendValues above). registers.xql falls
+    // back to rendering id/label as-is for any id it doesn't specifically recognize, so this
+    // doesn't need to match GND's vocabulary URIs, just the shape.
+    if (typeof values.gender === 'string' && values.gender) {
+      values.gender = [{ id: values.gender, label: values.gender }];
+    }
     return { id: rawId, ...values };
   }
 }

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -159,7 +159,7 @@ export class ReconciliationService extends Registry {
         label: item.name,
         link,
         details,
-        provider: 'Reconciliation',
+        provider: this._prefix ? `Reconciliation (${this._prefix})` : 'Reconciliation',
       };
     });
 

--- a/src/authority/reconciliation.js
+++ b/src/authority/reconciliation.js
@@ -85,6 +85,33 @@ function buildQueryZeroTwo(key, type, limit) {
 }
 
 /**
+ * Where to send a suggest/entity request, per the manifest's own `suggest.entity` field:
+ * 1.0-draft advertises it as a bare boolean (meaning "available at the spec's fixed
+ * "<endpoint>/suggest/entity" sub-path"); 0.2 advertises an explicit
+ * "{service_url, service_path}" pair instead, since 0.2 predates that fixed-path convention.
+ * Returns null if the manifest doesn't advertise entity suggestion at all.
+ */
+function suggestEntityUrl(endpoint, manifest) {
+  const suggest = manifest?.suggest?.entity;
+  if (!suggest) {
+    return null;
+  }
+  if (typeof suggest === 'object' && suggest.service_url) {
+    return `${suggest.service_url.replace(/\/$/, '')}${suggest.service_path || '/suggest/entity'}`;
+  }
+  return `${endpoint.replace(/\/$/, '')}/suggest/entity`;
+}
+
+/**
+ * Where to send an /extend data-extension request - always a fixed sub-path of the
+ * reconciliation endpoint itself in both protocol versions (unlike suggest, 0.2's manifest
+ * doesn't advertise a separate service_url/service_path for it).
+ */
+function extendUrl(endpoint) {
+  return `${endpoint.replace(/\/$/, '')}/extend`;
+}
+
+/**
  * Extract the ordered list of candidates from a result batch, regardless of
  * protocol version: 1.0-draft returns `{ results: [{ candidates }] }` (one entry
  * per submitted query, in order — this connector always submits exactly one);
@@ -95,6 +122,34 @@ function extractCandidates(version, json) {
     return json?.results?.[0]?.candidates ?? [];
   }
   return json?.q0?.result ?? [];
+}
+
+/**
+ * Extract propertyId -> first value from a data-extension response for a single requested id,
+ * regardless of protocol version: 1.0-draft's "rows" is an array of {id, properties: [{id,
+ * values: [{str}]}]}; 0.2's is an id-keyed object of propertyId-keyed value arrays directly (no
+ * per-property "id" field, since the key already is the property id). Only the first value of a
+ * (possibly multi-valued) property is used - a single value is what an XML attribute can
+ * meaningfully hold.
+ */
+function extractExtendValues(version, json, id) {
+  const values = {};
+  if (version === '0.2') {
+    const row = json?.rows?.[id];
+    if (row) {
+      Object.keys(row).forEach(propId => {
+        const first = row[propId]?.[0]?.str;
+        if (first !== undefined) values[propId] = first;
+      });
+    }
+  } else {
+    const row = (Array.isArray(json?.rows) ? json.rows : []).find(r => r.id === id);
+    (row?.properties || []).forEach(prop => {
+      const first = prop.values?.[0]?.str;
+      if (first !== undefined) values[prop.id] = first;
+    });
+  }
+  return values;
 }
 
 export class ReconciliationService extends Registry {
@@ -126,22 +181,70 @@ export class ReconciliationService extends Registry {
   }
 
   /**
-   * Query the authority and return a RegistryResult.
+   * Undo the `${this._prefix}-` prefix query() adds to every returned candidate's id (so it's a
+   * valid, collision-resistant xml:id fragment across multiple configured authorities), to get
+   * back the raw id this service itself actually knows about. Needed anywhere a raw id must be
+   * sent back to the service - info()'s preview lookup already did this inline; fetchExtend()/
+   * getRecord() below reuse the same logic rather than duplicating the substring arithmetic.
+   */
+  _stripPrefix(id) {
+    return this._prefix ? id.substring(this._prefix.length + 1) : id;
+  }
+
+  /**
+   * Fetch candidates via the service's lightweight /suggest/entity endpoint (type-ahead), if the
+   * manifest advertises it. Returns null (not an empty array) when the service doesn't support
+   * it, or the request itself fails, so callers can tell "no suggest support" apart from
+   * "genuinely zero candidates" and fall back to a full batch /reconcile query either way.
+   */
+  async _suggestCandidates(key) {
+    const url = suggestEntityUrl(this.endpoint, this.manifest);
+    if (!url) {
+      return null;
+    }
+    const params = new URLSearchParams({ prefix: key });
+    if (this.type) params.set('type', this.type);
+    if (this.limit) params.set('limit', this.limit);
+    try {
+      const response = await fetch(`${url}?${params.toString()}`);
+      if (!response.ok) {
+        return null;
+      }
+      const json = await response.json();
+      const suggestions = Array.isArray(json?.result) ? json.result : [];
+      // Reshape to look exactly like a full-query candidate item, minus fields /suggest/entity
+      // simply doesn't return (score, match, description) - so the mapping below, and anything a
+      // `fields` config might reference, doesn't need to know or care which endpoint was used.
+      return suggestions.map(s => ({ id: s.id, name: s.name, type: s.notable }));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Query the authority and return a RegistryResult. Prefers the lighter-weight
+   * /suggest/entity endpoint when the manifest advertises it (matching what OpenRefine's own
+   * type-ahead uses), falling back to a full batch /reconcile query otherwise - either way this
+   * method's own result shape stays identical, so nothing downstream needs to know which one
+   * actually ran.
    *
    * @param {String} key the search string
    */
   async query(key) {
     await this._manifestReady;
-    const { init } = this.version === '1.0-draft'
-      ? buildQueryOneDraft(key, this.type, this.limit)
-      : buildQueryZeroTwo(key, this.type, this.limit);
+    let candidates = await this._suggestCandidates(key);
+    if (!candidates) {
+      const { init } = this.version === '1.0-draft'
+        ? buildQueryOneDraft(key, this.type, this.limit)
+        : buildQueryZeroTwo(key, this.type, this.limit);
 
-    const response = await fetch(this.endpoint, init);
-    if (!response.ok) {
-      throw new Error(`Reconciliation query failed: ${response.status} ${response.statusText}`);
+      const response = await fetch(this.endpoint, init);
+      if (!response.ok) {
+        throw new Error(`Reconciliation query failed: ${response.status} ${response.statusText}`);
+      }
+      const json = await response.json();
+      candidates = extractCandidates(this.version, json);
     }
-    const json = await response.json();
-    const candidates = extractCandidates(this.version, json);
 
     const results = candidates.map(item => {
       let details;
@@ -160,6 +263,10 @@ export class ReconciliationService extends Registry {
         link,
         details,
         provider: this._prefix ? `Reconciliation (${this._prefix})` : 'Reconciliation',
+        // Kept available (not discarded) as a `fields` mapping source - "score" - beyond the
+        // id/label every connector already exposed. Undefined (silently omitted by
+        // buildProperties) for suggest-sourced results, which don't carry a score.
+        score: item.score,
       };
     });
 
@@ -185,7 +292,7 @@ export class ReconciliationService extends Registry {
       return {};
     }
     await this._manifestReady;
-    const rawId = this._prefix ? id.substring(this._prefix.length + 1) : id;
+    const rawId = this._stripPrefix(id);
 
     // 1.0-draft only requires manifest.preview to carry width/height, not a url — the
     // preview page itself lives at the fixed "<endpoint>/preview?id=..." sub-path.
@@ -215,5 +322,68 @@ export class ReconciliationService extends Registry {
       container.innerHTML = 'failed to load preview';
       throw error;
     }
+  }
+
+  /**
+   * Fetch additional property values for a single matched entry via the reconciliation
+   * protocol's data-extension endpoint (POST .../extend) - what makes an `extend:propId` source
+   * in a `fields` mapping (see Registry.buildProperties) resolve to a real value, e.g. pulling a
+   * GND identifier into its own output attribute alongside the plain name/id every connector
+   * already exposes.
+   *
+   * @param {string} id the (possibly prefixed) id to fetch extended properties for
+   * @param {string[]} propertyIds the property ids to fetch
+   * @returns {Promise<Object.<string, string>>} promise resolving to a map of propertyId -> value
+   */
+  async fetchExtend(id, propertyIds) {
+    await this._manifestReady;
+    const rawId = this._stripPrefix(id);
+    const url = this.version === '0.2' ? `${extendUrl(this.endpoint)}?version=0.2` : extendUrl(this.endpoint);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ids: [rawId],
+        properties: propertyIds.map(propId => ({ id: propId })),
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`Reconciliation extend request failed: ${response.status} ${response.statusText}`);
+    }
+    const json = await response.json();
+    return extractExtendValues(this.version, json, rawId);
+  }
+
+  /**
+   * Retrieve a raw JSON record for the given id, shaped for the Custom connector's own select()
+   * to POST onward as a new local-register entry (see custom.js) - without this, nesting
+   * ReconciliationService inside Custom could copy a match's id into the local register but never
+   * any of its other data, since Registry's own default getRecord() always rejects. Fetches every
+   * property this type advertises via /extend/propose, then their actual values via /extend, in
+   * one extra round trip each - acceptable here since getRecord() is only ever called once, right
+   * when the user explicitly picks a match to copy into the local register. Deliberately doesn't
+   * try to also fetch a display name here: doing so reliably would need id-based reconciliation
+   * (1.0-draft's optional matchType: "id" condition), which isn't guaranteed by every conforming
+   * service and isn't part of 0.2 at all - the id plus whatever /extend actually offers is already
+   * a strict improvement over today's complete lack of local-register support for this connector.
+   *
+   * @param {string} id the (possibly prefixed) id to look up
+   * @returns {Promise<Object>} promise resolving to a flat {id, ...extendedProperties} record
+   */
+  async getRecord(id) {
+    await this._manifestReady;
+    const rawId = this._stripPrefix(id);
+    const proposeUrl = `${this.endpoint.replace(/\/$/, '')}/extend/propose?type=${encodeURIComponent(this.type || '')}`;
+    const proposeResponse = await fetch(proposeUrl);
+    if (!proposeResponse.ok) {
+      throw new Error(`Reconciliation extend/propose request failed: ${proposeResponse.status} ${proposeResponse.statusText}`);
+    }
+    const proposed = await proposeResponse.json();
+    const propertyIds = (proposed?.properties || []).map(p => p.id);
+    const values = propertyIds.length > 0 ? await this.fetchExtend(id, propertyIds) : {};
+    return { id: rawId, ...values };
   }
 }

--- a/src/authority/registry.js
+++ b/src/authority/registry.js
@@ -1,6 +1,52 @@
 /* eslint-disable class-methods-use-this */
 
 /**
+ * Default target=source field mapping used when a <pb-authority> does not configure its own
+ * `fields` attribute: reproduces the connector's previous, hardcoded behaviour of writing the
+ * matched entry's id into a single "key" property. Kept as one shared constant so every
+ * connector's default is guaranteed identical and stays in sync if the default ever changes.
+ */
+const DEFAULT_FIELDS = 'key=id';
+
+/**
+ * Turn a free-text value (e.g. a candidate's label/name) into a token safe to use as an XML
+ * NMTOKEN-like id/attribute value: trims, collapses runs of whitespace/punctuation into a single
+ * hyphen, and strips any leading/trailing hyphen left over from that collapse. Mirrors the
+ * hyphen-separated id convention already used throughout this project's own demo data
+ * (e.g. "gnd-119442086", "kbga-actors-403") rather than inventing a new convention.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function slugify(value) {
+  return String(value)
+    .trim()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Parses a `fields` config attribute value ("target=source,target=source,...") into an array of
+ * { target, source } pairs. Falls back to DEFAULT_FIELDS when omitted/empty, so a <pb-authority>
+ * with no `fields` attribute at all reproduces exactly today's single-field behaviour.
+ *
+ * @param {string} raw
+ * @returns {{target: string, source: string}[]}
+ */
+export function parseFieldsConfig(raw) {
+  const spec = raw && raw.trim() ? raw : DEFAULT_FIELDS;
+  return spec
+    .split(',')
+    .map(pair => pair.trim())
+    .filter(pair => pair.length > 0)
+    .map(pair => {
+      const [target, source] = pair.split('=').map(s => s.trim());
+      return { target, source };
+    })
+    .filter(({ target, source }) => target && source);
+}
+
+/**
  * Abstract base class to be implemented by all connectors.
  */
 export class Registry {
@@ -11,6 +57,7 @@ export class Registry {
       properties: {},
     };
     this._register = this._config.name;
+    this._fields = parseFieldsConfig(configElem.getAttribute('fields'));
   }
 
   get register() {
@@ -75,5 +122,57 @@ export class Registry {
    */
   async getRecord(key) {
     return Promise.reject();
+  }
+
+  /**
+   * Fetch additional property values for a single matched entry beyond what `query()` already
+   * returned (e.g. a reconciliation service's data-extension endpoint). Connectors that have no
+   * such capability simply return an empty object - this is what makes an `extend:propId` source in
+   * a `fields` mapping resolve to "no value" (silently omitted, see buildProperties) rather than
+   * needing every connector to special-case unsupported extend sources.
+   *
+   * @param {string} id the id to fetch extended properties for
+   * @param {string[]} propertyIds the property ids to fetch
+   * @returns {Promise<Object.<string, *>>} promise resolving to a map of propertyId -> value
+   */
+  async fetchExtend(id, propertyIds) {
+    return {};
+  }
+
+  /**
+   * Build the `properties` map to attach to a selected match, per this connector's `fields`
+   * config (see parseFieldsConfig) - the general mechanism every connector shares for letting an
+   * admin configure which of a match's fields end up in which output attribute, instead of the
+   * single hardcoded "id -> key" mapping used previously. A source of `id`/`label`/`type`/`score`
+   * is read directly off the candidate `item` (as returned by this connector's own `query()`);
+   * a source of `extend:propId` is fetched via one batched `fetchExtend()` call. Only the `label`
+   * source is slug-escaped (see `slugify`) - `id`/`type`/`score`/extend-sourced values are used
+   * as-is, since they are typically already-safe tokens or, for extend properties, may be URIs
+   * that slugifying would corrupt. A mapping whose source has no value on this particular item
+   * (e.g. an unset `extend:` property) is silently omitted, not written as an empty string.
+   *
+   * @param {Object} item one result item as returned by this connector's query()
+   * @returns {Promise<Object.<string, string>>} promise resolving to the properties map
+   */
+  async buildProperties(item) {
+    const extendSources = [
+      ...new Set(
+        this._fields
+          .map(({ source }) => source)
+          .filter(source => source.startsWith('extend:'))
+          .map(source => source.slice('extend:'.length)),
+      ),
+    ];
+    const extended = extendSources.length > 0 ? await this.fetchExtend(item.id, extendSources).catch(() => ({})) : {};
+
+    const properties = {};
+    this._fields.forEach(({ target, source }) => {
+      const value = source.startsWith('extend:') ? extended[source.slice('extend:'.length)] : item[source];
+      if (value === undefined || value === null || value === '') {
+        return;
+      }
+      properties[target] = source === 'label' ? slugify(value) : value;
+    });
+    return properties;
   }
 }

--- a/src/pb-authority-lookup.js
+++ b/src/pb-authority-lookup.js
@@ -211,8 +211,17 @@ export class PbAuthorityLookup extends themableMixin(pbMixin(LitElement)) {
    * "GND", "GeoNames" - shown so a federated lookup, i.e. Custom wrapping several nested
    * connectors, see custom.js, doesn't present merged results as if they all came from one
    * place).
+   *
+   * `item.label` is rendered as raw HTML via unsafeHTML() *only* when a connector
+   * explicitly opts in via `item.labelIsHtml` (today, only KBGA's bibl/songs registers,
+   * whose remote API returns a real, pre-formatted "asHtml" field - see kbga.js). Every
+   * other connector's label is plain text and must stay auto-escaped: ReconciliationService
+   * and Custom in particular surface labels extracted straight from document content
+   * (persName etc.), which anyone with document-edit access can influence - rendering that
+   * unconditionally as HTML was a real, confirmed stored-XSS vector before this flag existed.
    */
   _formatItem(item) {
+    const label = item.labelIsHtml ? unsafeHTML(item.label) : item.label;
     return html`
       <li>
         <div>
@@ -229,8 +238,8 @@ export class PbAuthorityLookup extends themableMixin(pbMixin(LitElement)) {
             </svg>
           </button>
           ${item.link
-            ? html`<a target="_blank" href="${item.link}">${unsafeHTML(item.label)}</a>`
-            : html`${unsafeHTML(item.label)}`}
+            ? html`<a target="_blank" href="${item.link}">${label}</a>`
+            : html`${label}`}
           <div class="badges">
             ${item.occurrences > 0
               ? html`<span class="occurrences badge" part="occurrences">${item.occurrences}</span>`

--- a/src/pb-authority-lookup.js
+++ b/src/pb-authority-lookup.js
@@ -351,14 +351,19 @@ export class PbAuthorityLookup extends themableMixin(pbMixin(LitElement)) {
     `;
   }
 
-  _select(item) {
+  async _select(item) {
     const connector = this._authorities[item.register];
+    // Build the properties map from the connector's own `fields` config (see
+    // Registry.buildProperties/parseFieldsConfig) instead of the single hardcoded
+    // `{ ref: item.id }` this used to always emit - lets an admin configure which of a match's
+    // fields (id, label, type, score, or an extend:-sourced property) end up under which output
+    // property name. Falls back to the same default mapping a connector with no `fields`
+    // attribute configured would produce, for the edge case of no registered connector at all.
+    const properties = connector ? await connector.buildProperties(item).catch(() => ({ key: item.id })) : { key: item.id };
     const options = {
       strings: item.strings,
       type: item.register,
-      properties: {
-        ref: item.id,
-      },
+      properties,
     };
     if (connector) {
       connector

--- a/src/pb-authority-lookup.js
+++ b/src/pb-authority-lookup.js
@@ -87,6 +87,12 @@ export class PbAuthorityLookup extends themableMixin(pbMixin(LitElement)) {
     this._authorities = {};
     this.noOccurrences = false;
     this.group = 'tei';
+    // Debounce search-as-you-type (_queryChanged -> _scheduleQuery) and guard against
+    // out-of-order responses: each _query() call captures the current _queryGeneration,
+    // and every async continuation (query() itself, then the occurrences() round-trip)
+    // checks it's still current before touching `this._results`. Without this, a fast
+    // keystroke could let an earlier request's response land after a later one's and
+    // silently overwrite fresher results with stale ones.
     this._queryGeneration = 0;
     this._queryDebounceMs = 300;
   }
@@ -197,6 +203,15 @@ export class PbAuthorityLookup extends themableMixin(pbMixin(LitElement)) {
     return info;
   }
 
+  /**
+   * Each result item carries three independent badges: `register` (its authority type,
+   * always present), `occurrences` (how often this entity is already referenced elsewhere
+   * in the current document, fetched separately via _occurrences() below), and `source`
+   * (the `provider` label a connector's own query() tags its results with, e.g. "local",
+   * "GND", "GeoNames" - shown so a federated lookup, i.e. Custom wrapping several nested
+   * connectors, see custom.js, doesn't present merged results as if they all came from one
+   * place).
+   */
   _formatItem(item) {
     return html`
       <li>

--- a/src/pb-load.js
+++ b/src/pb-load.js
@@ -358,7 +358,14 @@ export class PbLoad extends themableMixin(pbMixin(LitElement)) {
   }
 
   _handleContent(ev) {
-    const resp = this.shadowRoot.getElementById('loadContent').lastResponse;
+    // Use the response carried by this specific request (ev.detail is the iron-ajax
+    // `request` object), not the shared <iron-ajax>'s `lastResponse`: iron-ajax fires
+    // `response` for every completed request, including ones superseded by a newer
+    // request started in the meantime, but only updates `lastResponse` for the most
+    // recent request. Reading `lastResponse` here could pick up a stale value from an
+    // earlier request - or, on the very first request, `undefined` - and briefly
+    // render the literal text "undefined" into the page.
+    const resp = ev.detail.response;
     if (this.container) {
       this.style.display = 'none';
       document.querySelectorAll(this.container).forEach(elem => {

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -1351,6 +1351,19 @@ class PbViewAnnotate extends PbView {
           margin-top: 1em;
         }
 
+        /* A reconciliation service's preview HTML (injected here via
+         * pb-annotation-detail -- see annotations.js) is not bounded in size: a
+         * service may reasonably list several properties, or an image thumbnail,
+         * making the rendered content taller than the handful of lines this popup
+         * was originally sized for. Cap it and let it scroll internally instead of
+         * growing unbounded and overlapping/obscuring other page content -- a
+         * click-to-view info popup should stay compact regardless of how rich the
+         * underlying preview is. */
+        .annotation-popup .info {
+          max-height: 16em;
+          overflow-y: auto;
+        }
+
         .annotation-popup table {
           width: 100%;
         }

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -436,15 +436,21 @@ class PbViewAnnotate extends PbView {
     this._scheduleMarkerRefresh();
   }
 
+  /** Which JSON property of an annotation's data holds its authority id, for this type. */
   getKey(type) {
     return this.keyMap[type] || this.key;
   }
 
   /**
-   * Resolve the identifier for an annotation's data, falling back to the
-   * legacy `key` attribute when the type-specific key (e.g. `ref`) is not
-   * present. This keeps annotations authored before a `keyMap` was
-   * configured (which only ever set `@key`) working correctly.
+   * Resolve the id from an annotation's data, falling back to the legacy `key` property
+   * when the type's configured key (getKey(), typically `ref`) is absent. Needed because
+   * `keyMap`/`ref`-based ids are a later addition: any annotation created before a type's
+   * keyMap entry existed only ever had `key` set, and would otherwise look id-less (see
+   * onTrigger below, where "no id" means "show a raw properties table instead of an entity
+   * preview"). Use this instead of a plain `data[getKey(type)]` read anywhere an annotation
+   * might predate its type's current keyMap config; call sites that only ever *write* fresh
+   * annotation data (e.g. _updateAnnotation, search()'s result entries) don't need it, since
+   * they use the current key convention consistently by construction.
    */
   getId(data, type) {
     const primaryKey = this.getKey(type);
@@ -653,6 +659,11 @@ class PbViewAnnotate extends PbView {
 
     console.log('<pb-view-annotate> Range: %o', range);
     const span = document.createElement('span');
+    // In practice this never matches: addAnnotation()/updateAnnotation() always run
+    // properties through clearProperties() first, which drops empty-string values
+    // entirely rather than leaving them as ''. A brand-new annotation's initial
+    // "incomplete" styling is set later, by _markIncompleteAnnotations() (which uses
+    // getId()'s absent-or-empty check, not this strict === '' one).
     const addClass = teiRange.properties[this.getKey(teiRange.type)] === '' ? 'incomplete' : '';
     span.className = `annotation annotation-${teiRange.type} ${teiRange.type} ${addClass} ${
       teiRange.before ? 'before' : ''
@@ -1032,6 +1043,8 @@ class PbViewAnnotate extends PbView {
         })`;
         const id = this.getId(data, type);
         if (id) {
+          // Linked entity: let whoever handles pb-annotation-detail (e.g. annotations.js)
+          // fetch and render a real preview into `info`.
           this.emitTo('pb-annotation-detail', {
             type,
             id,
@@ -1040,7 +1053,10 @@ class PbViewAnnotate extends PbView {
             ready: () => instance.setContent(wrapper),
           });
         } else {
-          // show properties as key/value table
+          // Not linked to anything yet (or a non-authority annotation type, which has no
+          // id concept at all): fall back to a plain key/value dump of whatever properties
+          // it does have, e.g. for `sic`/`reg`/`app` annotations that don't reference an
+          // authority entry.
           info.innerHTML = '';
           const keys = Object.keys(data);
           if (keys.length === 0) {
@@ -1178,6 +1194,8 @@ class PbViewAnnotate extends PbView {
         if (annoData && annoType) {
           const parsed = JSON.parse(annoData) || {};
           isAnnotated = annoType === type;
+          // getId(), not a plain getKey() lookup: a text occurrence can already be tagged
+          // with a legacy @key-only annotation (see getId's doc comment).
           ref = this.getId(parsed, type);
         }
 
@@ -1193,6 +1211,9 @@ class PbViewAnnotate extends PbView {
           textNode: node,
           kwic: kwicText(str, start + match.index, start + end),
         };
+        // Written under the canonical key name (getKey), not getId: this builds a fresh
+        // result entry for the "other occurrences" UI, so there is no legacy shape to
+        // preserve here the way there is when reading an existing annotation's data.
         entry[this.getKey(type)] = ref;
         result.push(entry);
       }

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -659,12 +659,13 @@ class PbViewAnnotate extends PbView {
 
     console.log('<pb-view-annotate> Range: %o', range);
     const span = document.createElement('span');
-    // In practice this never matches: addAnnotation()/updateAnnotation() always run
-    // properties through clearProperties() first, which drops empty-string values
-    // entirely rather than leaving them as ''. A brand-new annotation's initial
-    // "incomplete" styling is set later, by _markIncompleteAnnotations() (which uses
-    // getId()'s absent-or-empty check, not this strict === '' one).
-    const addClass = teiRange.properties[this.getKey(teiRange.type)] === '' ? 'incomplete' : '';
+    // Same absent-or-empty check _markIncompleteAnnotations() uses below, via getId()'s
+    // key-with-legacy-@key-fallback resolution - a strict === '' comparison against
+    // properties[getKey(type)] would never match here, since addAnnotation()/
+    // updateAnnotation() always run properties through clearProperties() first, which
+    // drops empty-string values entirely rather than leaving them as ''.
+    const id = this.getId(teiRange.properties, teiRange.type);
+    const addClass = !id || id.length === 0 ? 'incomplete' : '';
     span.className = `annotation annotation-${teiRange.type} ${teiRange.type} ${addClass} ${
       teiRange.before ? 'before' : ''
     }`;

--- a/src/pb-view-annotate.js
+++ b/src/pb-view-annotate.js
@@ -440,6 +440,23 @@ class PbViewAnnotate extends PbView {
     return this.keyMap[type] || this.key;
   }
 
+  /**
+   * Resolve the identifier for an annotation's data, falling back to the
+   * legacy `key` attribute when the type-specific key (e.g. `ref`) is not
+   * present. This keeps annotations authored before a `keyMap` was
+   * configured (which only ever set `@key`) working correctly.
+   */
+  getId(data, type) {
+    const primaryKey = this.getKey(type);
+    if (data[primaryKey]) {
+      return data[primaryKey];
+    }
+    if (primaryKey !== 'key' && data.key) {
+      return data.key;
+    }
+    return data[primaryKey];
+  }
+
   _resizeHandler() {
     let _pendingCallback = null;
 
@@ -903,7 +920,7 @@ class PbViewAnnotate extends PbView {
     const jsonOld = JSON.parse(span.dataset.annotation);
     const json = Object.assign(jsonOld || {}, properties);
     span.dataset.annotation = JSON.stringify(json);
-    if (json[this.getKey(span.dataset.type)] !== '') {
+    if (this.getId(json, span.dataset.type)) {
       span.classList.remove('incomplete');
     }
     this._scheduleMarkerRefresh();
@@ -1013,10 +1030,11 @@ class PbViewAnnotate extends PbView {
         typeInd.style.color = `var(${
           color && color.isLight ? '--pb-color-primary' : '--pb-color-inverse'
         })`;
-        if (data[this.getKey(type)]) {
+        const id = this.getId(data, type);
+        if (id) {
           this.emitTo('pb-annotation-detail', {
             type,
-            id: data[this.getKey(type)],
+            id,
             container: info,
             span,
             ready: () => instance.setContent(wrapper),
@@ -1160,7 +1178,7 @@ class PbViewAnnotate extends PbView {
         if (annoData && annoType) {
           const parsed = JSON.parse(annoData) || {};
           isAnnotated = annoType === type;
-          ref = parsed[this.getKey(type)];
+          ref = this.getId(parsed, type);
         }
 
         const startRange = rangeToPoint(node, match.index);
@@ -1231,8 +1249,8 @@ class PbViewAnnotate extends PbView {
     elem.querySelectorAll('.annotation.authority').forEach(annotation => {
       if (annotation.dataset.type) {
         const data = JSON.parse(annotation.dataset.annotation);
-        const key = this.getKey(annotation.dataset.type);
-        if (!data[key] || data[key].length === 0) {
+        const id = this.getId(data, annotation.dataset.type);
+        if (!id || id.length === 0) {
           annotation.classList.add('incomplete');
         } else {
           annotation.classList.remove('incomplete');


### PR DESCRIPTION
# Reconciliation and authority connector update

This is related to a major overhaul of the reconciliation function in TEI Publisher. It is meant to benefit from TEI Publisher itself serving as a reconciliation service, and improvements to the *annotate* profile which are implemented in [Jinks' PR 386](https://github.com/eeditiones/jinks/pull/386). However, in the end the changes to the tei-publisher-components and to the *annotate* profile work independently of the *reconcile* profile and facilitate taking advantage of more, or more recent, reconciliation API functions offered by *any* reconciliation service, e.g. those listed on https://reconciliation-api.github.io/testbench/0.2/#/ ...

## More fields going to TEI attributes

The reconciliation protocol provides for multiple fields besides the respective `id`/`url` being returned when reconciling. (In fact, many of the other authority databases also provide more information in their responses.) In order to benefit from that, the annotation/authority lookup mechanism(s) need to have a mapping of where (e.g. which TEI `@attribute`) each returned field should go. This lets an instance's admin configure which of a match's fields end up in which output attribute, instead of the single hardcoded "id -> key" mapping used previously (which is retained as a fallback, see the `parseFieldsConfig()` function in `src/authority/registry.js` and the `getId()` function in `src/pb-view-annotate.js`). Introducing this mapping was the change that affected the most files.

The map can be given in a `@fields` attribute in the authority definition in `[profiles/annotate/]templates/pages/annotate-tei.html` and looks like this:

```xml
<pb-authority connector="gnd" name="organization" fields="ref=id,link=extend:link,target_attribute=source_field">
```

A config that specifies an `extend:propId` source for a connector that doesn't support this, has this field silently omitted (i.e. no corresponding attribute is being created at all).

With regard to the distinction between what the initial query returned (in addition to the id) and what a later extend request would provide, i.e. which source fields need not be prefixed with `extend:`, this obviously depends on the respective authority db. For reconciliation API services: A source field of `id`/`label`/`type`/`score` is read directly off the candidate `item` (as returned by this connector's own `query()`), whereas other source fields need to be specified as `extend:propId` and are fetched via one batched `fetchExtend()` call.

## More versions of the Reconciliation API

The Reconciliation API authority lookup now follows API versions v0.2 and v1.0-draft. This - and adding the data extension facility described above - implied many changes to `src/authority/reconciliation.js`.

## A XSS fix I ran into

It seems a XSS vulnerability existed due to authority services sometimes providing ready-made html in label fields. This applied only to KBGA, it is now managed by having connectors explicity opt in via `item.labelIsHtml`. Doing so makes `item.label` be rendered as raw HTML via unsafeHTML(). By default, a label is considered plain text and must stay auto-escaped. ReconciliationService and Custom in particular surface labels extracted straight from document content (persName etc.), which anyone with document-edit access can influence - rendering that unconditionally as HTML is a stored-XSS vector.

## More changes

Besides the `src/authority/reconciliation.js` file, here are important changes in the following files:

- `src/authority/registry.js`:
    - add the fields mapping config parsing (`parseFieldsConfig()`, `buildProperties()`)
    - add a function to guard against freetext field values in `label` ending up as invalid (id) `@attributes` (presently only the `label` source field is guarded/slugified - `id`/`type`/`score`/extend-sourced values are used as-is, since they are typically already-safe tokens or, for extend properties, may be URIs that slugifying would corrupt)
- `src/authority/{geonames.js,gnd.js,kbga.js}`:
    - identical updates to add the extension fields mechanism via `fetchExtend()`
    - also, improve fields handling in geonames
    - handle `gnd` fieldname conflicts with other connectors in gnd
    - and handle html escaping ambiguity in kbga.
- `src/authority/custom.js`:
    - add a function to delegate data-extension fetching to whichever wrapped sub-connector actually implements it. It mirrors how the already established `select()` function delegates `getRecord()`.
- `src/authority/connectors.js`:
    - this has just improved the way unrecognized connectors are handled. Before they would silently be treated as `Metagrid` connectors, now they still do so, but there is an error message about it in the console.
- `src/pb-authority-lookup.js`:
    - make use of the `parseFieldsConfig()` and `buildProperties()` functions
    - catch a rawHTML handling issue
    - asyncify the `select()` function.
- `src/pb-load.js`:
    - use `ev.detail.response` carried by this specific request (ev.detail is the iron-ajax `request` object), not the shared `this.shadowRoot.getElementById('loadContent').lastResponse`. Reading the latter here could pick up a stale value from an earlier request - or, on the very first request, `undefined` - and briefly render the literal text "undefined" into the page.
- `src/pb-view-annotate.js`:
    - provide and use a `getId()` function in order to be independent of the hardcoded key=id association.
